### PR TITLE
Fix performance problem and minor bug.

### DIFF
--- a/src/main/java/org/simplejavamail/outlookmessageparser/OutlookMessageParser.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/OutlookMessageParser.java
@@ -581,7 +581,7 @@ public class OutlookMessageParser {
 			} else {
 				// a directory within the attachment directory entry  means that a .msg file is attached at this point.
 				// we recursively parse this .msg file and add it as a OutlookMsgAttachment object to the current OutlookMessage object.
-				final OutlookMessage attachmentMsg = new OutlookMessage();
+				final OutlookMessage attachmentMsg = new OutlookMessage(rtf2htmlConverter);
 				final OutlookMsgAttachment msgAttachment = new OutlookMsgAttachment(attachmentMsg);
 				msg.addAttachment(msgAttachment);
 				checkDirectoryEntry((DirectoryEntry) entry, attachmentMsg);

--- a/src/main/java/org/simplejavamail/outlookmessageparser/rtf/SimpleRTF2HTMLConverter.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/rtf/SimpleRTF2HTMLConverter.java
@@ -45,20 +45,32 @@ public class SimpleRTF2HTMLConverter implements RTF2HTMLConverter {
 	 * @return The text with replaced special characters that denote hex codes for strings using Windows CP1252 encoding.
 	 */
 	private String replaceHexSequences(final String text) {
-		final Matcher m = compile("\\\\'(..)").matcher(text);
+		StringBuilder res = null;
+	  	final Matcher m = compile("\\\\'(..)").matcher(text);
 
-		String replacedText = text;
+		int lastPosition = 0;
+
 		while (m.find()) {
-			for (int g = 1; g <= m.groupCount(); g++) {
-				final String hex = m.group(g);
-				final String hexToString = hexToString(hex);
-				if (hexToString != null) {
-					replacedText = replacedText.replaceAll("\\\\'" + hex, hexToString);
-				}
+		    if (res == null)
+		        res = new StringBuilder();
+
+			res.append(text, lastPosition, m.start());
+
+			final String hex = m.group(1);
+			final String hexToString = hexToString(hex);
+			if (hexToString != null) {
+				res.append(hexToString);
 			}
+
+			lastPosition = m.end();
 		}
 
-		return replacedText;
+        if (res == null)
+            return text;
+
+		res.append(text, lastPosition, text.length());
+
+		return res.toString();
 	}
 
 	/**


### PR DESCRIPTION
replaceHexSequences() took a lot of time because .replaceAll() was called on all text for each HEX escaping.