### PR TITLE
#9 Implemented RTF to HTML conversion according to RTF spec

### DIFF
--- a/src/main/java/org/simplejavamail/outlookmessageparser/rtf/util/CharsetHelper.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/rtf/util/CharsetHelper.java
@@ -23,7 +23,7 @@ public class CharsetHelper {
 	
 	public static final Charset WINDOWS_CHARSET = Charset.forName("CP1252");
 	
-	public static Charset findCharset(String rtfCodePage) {
+	public static Charset findCharset(Integer rtfCodePage) {
 		for (String prefix : CHARSET_PREFIXES) {
 			try {
 				return Charset.forName(prefix + rtfCodePage);
@@ -31,6 +31,6 @@ public class CharsetHelper {
 				// ignore
 			}
 		}
-		throw new UnsupportedCharsetException(rtfCodePage);
+		throw new UnsupportedCharsetException("" + rtfCodePage);
 	}
 }

--- a/src/test/java/org/simplejavamail/outlookmessageparser/HighoverEmailsTest.java
+++ b/src/test/java/org/simplejavamail/outlookmessageparser/HighoverEmailsTest.java
@@ -28,10 +28,11 @@ import org.simplejavamail.outlookmessageparser.model.OutlookSmime.OutlookSmimeMu
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Scanner;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.simplejavamail.outlookmessageparser.TestUtils.classpathFileToString;
+import static org.simplejavamail.outlookmessageparser.TestUtils.normalizeText;
 
 public class HighoverEmailsTest {
 
@@ -492,8 +493,7 @@ public class HighoverEmailsTest {
 				"酒店研发部\n" +
 				" \n");
 
-		InputStream resourceAsStream = OutlookMessageParser.class.getClassLoader().getResourceAsStream("test-messages/chinese message.html");
-		String expectedHtml = new Scanner(resourceAsStream, UTF_8.name()).useDelimiter("\\A").next();
+		String expectedHtml = classpathFileToString("/test-messages/chinese message.html", UTF_8);
 		assertThat(normalizeText(msg.getConvertedBodyHTML())).isEqualTo(normalizeText(expectedHtml));
 	}
 
@@ -760,9 +760,7 @@ public class HighoverEmailsTest {
 		assertThat(normalizeText(msg.getBodyText())).isEqualTo("We should meet up!\n");
 		// Outlook overrode this value too OR converted the original HTML to RTF, from which OutlookMessageParser derived this HTML
 		assertThat(normalizeText(msg.getConvertedBodyHTML())).isEqualTo(
-				"<html><body style=\"font-family:'Courier',monospace;font-size:10pt;\">        \n" +
-						"      <b>   We should meet up!  </b>    <img src=\"cid:thumbsup\">\n" +
-						" </body></html>");
+				"<b>We should meet up!</b><img src=\"cid:thumbsup\">");
 		// the RTF was probably created by Outlook based on the HTML when the message was saved
 		assertThat(msg.getBodyRTF()).isNotEmpty();
 		List<OutlookAttachment> outlookAttachments = msg.getOutlookAttachments();
@@ -801,10 +799,6 @@ public class HighoverEmailsTest {
 		recipient.setName(toName);
 		recipient.setAddress(toEmail);
 		return recipient;
-	}
-
-	private static String normalizeText(String text) {
-		return text.replaceAll("\\r\\n", "\n").replaceAll("\\r", "\n");
 	}
 
 	private static OutlookMessage parseMsgFile(String msgPath)

--- a/src/test/java/org/simplejavamail/outlookmessageparser/TestUtils.java
+++ b/src/test/java/org/simplejavamail/outlookmessageparser/TestUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) ${project.inceptionYear} Benny Bottema (benny@bennybottema.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.simplejavamail.outlookmessageparser;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestUtils {
+    public static String classpathFileToString(String classPathFile, Charset charset) {
+        try {
+            Path path = Paths.get(TestUtils.class.getResource(classPathFile).toURI());
+            return Files.readString(path, charset);
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public static String normalizeText(String text) {
+        return text.replaceAll("\\r\\n", "\n").replaceAll("\\r", "\n");
+    }
+}

--- a/src/test/java/org/simplejavamail/outlookmessageparser/rtf/SimpleRTF2HTMLConverterTest.java
+++ b/src/test/java/org/simplejavamail/outlookmessageparser/rtf/SimpleRTF2HTMLConverterTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) ${project.inceptionYear} Benny Bottema (benny@bennybottema.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.simplejavamail.outlookmessageparser.rtf;
+
+import org.junit.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.simplejavamail.outlookmessageparser.TestUtils.classpathFileToString;
+import static org.simplejavamail.outlookmessageparser.TestUtils.normalizeText;
+
+public class SimpleRTF2HTMLConverterTest {
+
+    @Test
+    public void testConversion()  {
+        SimpleRTF2HTMLConverter converter = new SimpleRTF2HTMLConverter();
+        String rtf = classpathFileToString("/test-messages/rtf-to-html-input.rtf", UTF_8);
+        String expectedHtml = classpathFileToString("/test-messages/rtf-to-html-output.html", UTF_8);
+
+        String html = converter.rtf2html(rtf);
+        assertEquals(normalizeText(expectedHtml), normalizeText(html));
+    }
+
+}

--- a/src/test/resources/test-messages/chinese message.html
+++ b/src/test/resources/test-messages/chinese message.html
@@ -1,1037 +1,588 @@
-<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40">
- <head>
- <meta name=ProgId content=Word.Document>
- <meta name=Generator content="Microsoft Word 15">
- <meta name=Originator content="Microsoft Word 15">
- <link rel=File-List href="cid:filelist.xml@01D435C0.4C83B540">
- <!--[if gte mso 9]><xml>
- <o:OfficeDocumentSettings>
- <o:AllowPNG/>
- </o:OfficeDocumentSettings>
- </xml><![endif]-->
- <link rel=themeData href="~~themedata~~">
- <link rel=colorSchemeMapping href="~~colorschememapping~~">
- <!--[if gte mso 9]><xml>
- <w:WordDocument>
- <w:SpellingState>Clean</w:SpellingState>
- <w:TrackMoves/>
- <w:TrackFormatting/>
- <w:EnvelopeVis/>
- <w:PunctuationKerning/>
- <w:DrawingGridVerticalSpacing>7.8 磅</w:DrawingGridVerticalSpacing>
- <w:DisplayHorizontalDrawingGridEvery>0</w:DisplayHorizontalDrawingGridEvery>
- <w:DisplayVerticalDrawingGridEvery>2</w:DisplayVerticalDrawingGridEvery>
- <w:ValidateAgainstSchemas/>
- <w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>
- <w:IgnoreMixedContent>false</w:IgnoreMixedContent>
- <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>
- <w:DoNotPromoteQF/>
- <w:LidThemeOther>EN-US</w:LidThemeOther>
- <w:LidThemeAsian>ZH-CN</w:LidThemeAsian>
- <w:LidThemeComplexScript>X-NONE</w:LidThemeComplexScript>
- <w:Compatibility>
- <w:SpaceForUL/>
- <w:BalanceSingleByteDoubleByteWidth/>
- <w:DoNotLeaveBackslashAlone/>
- <w:ULTrailSpace/>
- <w:DoNotExpandShiftReturn/>
- <w:AdjustLineHeightInTable/>
- <w:BreakWrappedTables/>
- <w:SnapToGridInCell/>
- <w:WrapTextWithPunct/>
- <w:UseAsianBreakRules/>
- <w:DontGrowAutofit/>
- <w:SplitPgBreakAndParaMark/>
- <w:EnableOpenTypeKerning/>
- <w:DontFlipMirrorIndents/>
- <w:OverrideTableStyleHps/>
- <w:UseFELayout/>
- </w:Compatibility>
- <w:BrowserLevel>MicrosoftInternetExplorer4</w:BrowserLevel>
- <m:mathPr>
- <m:mathFont m:val="Cambria Math"/>
- <m:brkBin m:val="before"/>
- <m:brkBinSub m:val="&#45;-"/>
- <m:smallFrac m:val="off"/>
- <m:dispDef/>
- <m:lMargin m:val="0"/>
- <m:rMargin m:val="0"/>
- <m:defJc m:val="centerGroup"/>
- <m:wrapIndent m:val="1440"/>
- <m:intLim m:val="subSup"/>
- <m:naryLim m:val="undOvr"/>
- </m:mathPr></w:WordDocument>
- </xml><![endif]-->
- <!--[if gte mso 9]><xml>
- <w:LatentStyles DefLockedState="false" DefUnhideWhenUsed="false" DefSemiHidden="false" DefQFormat="false" DefPriority="99" LatentStyleCount="371">
- <w:LsdException Locked="false" Priority="0" QFormat="true" Name="Normal"/>
- <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 1"/>
- <w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 2"/>
- <w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 3"/>
- <w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 4"/>
- <w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 5"/>
- <w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 6"/>
- <w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 7"/>
- <w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 8"/>
- <w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 9"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 4"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 5"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 6"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 7"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 8"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 9"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 1"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 2"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 3"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 4"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 5"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 6"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 7"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 8"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 9"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Normal Indent"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="footnote text"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="annotation text"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="header"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="footer"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index heading"/>
- <w:LsdException Locked="false" Priority="35" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="caption"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="table of figures"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="envelope address"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="envelope return"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="footnote reference"/>
- <w:LsdException Locked="false" SemiHi
- dden="true" UnhideWhenUsed="true" Name="annotation reference"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="line number"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="page number"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="endnote reference"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="endnote text"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="table of authorities"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="macro"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="toa heading"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List 4"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List 5"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet 4"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet 5"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number 4"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number 5"/>
- <w:LsdException Locked="false" Priority="10" QFormat="true" Name="Title"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Closing"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Signature"/>
- <w:LsdException Locked="false" Priority="1" SemiHidden="true" UnhideWhenUsed="true" Name="Default Paragraph Font"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text Indent"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue 4"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue 5"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Message Header"/>
- <w:LsdException Locked="false" Priority="11" QFormat="true" Name="Subtitle"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Salutation"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Date"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text First Indent"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text First Indent 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Note Heading"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text Indent 2"/>
- 
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text Indent 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Block Text"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Hyperlink"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="FollowedHyperlink"/>
- <w:LsdException Locked="false" Priority="22" QFormat="true" Name="Strong"/>
- <w:LsdException Locked="false" Priority="20" QFormat="true" Name="Emphasis"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Document Map"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Plain Text"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="E-mail Signature"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Top of Form"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Bottom of Form"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Normal (Web)"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Acronym"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Address"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Cite"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Code"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Definition"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Keyboard"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Preformatted"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Sample"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Typewriter"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Variable"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Normal Table"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="annotation subject"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="No List"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Outline List 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Outline List 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Outline List 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Simple 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Simple 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Simple 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Classic 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Classic 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Classic 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Classic 4"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Colorful 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Colorful 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Colorful 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 4"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 5"/>
- <w:LsdE
- xception Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 4"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 5"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 6"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 7"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 8"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 4"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 5"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 6"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 7"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 8"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table 3D effects 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table 3D effects 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table 3D effects 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Contemporary"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Elegant"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Professional"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Subtle 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Subtle 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Web 1"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Web 2"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Web 3"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Balloon Text"/>
- <w:LsdException Locked="false" Priority="39" Name="Table Grid"/>
- <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Theme"/>
- <w:LsdException Locked="false" SemiHidden="true" Name="Placeholder Text"/>
- <w:LsdException Locked="false" Priority="1" QFormat="true" Name="No Spacing"/>
- <w:LsdException Locked="false" Priority="60" Name="Light Shading"/>
- <w:LsdException Locked="false" Priority="61" Name="Light List"/>
- <w:LsdException Locked="false" Priority="62" Name="Light Grid"/>
- <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1"/>
- <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2"/>
- <w:LsdException Locked="false" Priority="65" Name="Medium List 1"/>
- <w:LsdException Locked="false" Priority="66" Name="Medium List 2"/>
- <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1"/>
- <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2"/>
- <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3"/>
- <w:LsdException Locked="false" Priority="70" Name="Dark List"/>
- <w:LsdException Locked="false" Priority="71" Name="Colorful Shading"/>
- <w:LsdException Locked="false" Priority="72" Name="Colorful List"/>
- <w:LsdException Locked="false" Priority="73" Name="Colorful Grid"/>
- <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 1"/>
- <w:LsdException Locked="false" Priority="61" Name="Light List Accent 1"/>
- <w:Lsd
- Exception Locked="false" Priority="62" Name="Light Grid Accent 1"/>
- <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 1"/>
- <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 1"/>
- <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 1"/>
- <w:LsdException Locked="false" SemiHidden="true" Name="Revision"/>
- <w:LsdException Locked="false" Priority="34" QFormat="true" Name="List Paragraph"/>
- <w:LsdException Locked="false" Priority="29" QFormat="true" Name="Quote"/>
- <w:LsdException Locked="false" Priority="30" QFormat="true" Name="Intense Quote"/>
- <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 1"/>
- <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 1"/>
- <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 1"/>
- <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 1"/>
- <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 1"/>
- <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 1"/>
- <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 1"/>
- <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 1"/>
- <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 2"/>
- <w:LsdException Locked="false" Priority="61" Name="Light List Accent 2"/>
- <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 2"/>
- <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 2"/>
- <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 2"/>
- <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 2"/>
- <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 2"/>
- <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 2"/>
- <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 2"/>
- <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 2"/>
- <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 2"/>
- <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 2"/>
- <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 2"/>
- <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 2"/>
- <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 3"/>
- <w:LsdException Locked="false" Priority="61" Name="Light List Accent 3"/>
- <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 3"/>
- <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 3"/>
- <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 3"/>
- <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 3"/>
- <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 3"/>
- <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 3"/>
- <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 3"/>
- <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 3"/>
- <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 3"/>
- <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 3"/>
- <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 3"/>
- <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 3"/>
- <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 4"/>
- <w:LsdException Locked="false" Priority="61" Name="Light List Accent 4"/>
- <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 4"/>
- <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 4"/>
- <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 4"/>
- <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 4"/>
- <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 4"/>
- <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 4"/>
- <w:LsdException Locked="false" Priority="68" 
- Name="Medium Grid 2 Accent 4"/>
- <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 4"/>
- <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 4"/>
- <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 4"/>
- <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 4"/>
- <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 4"/>
- <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 5"/>
- <w:LsdException Locked="false" Priority="61" Name="Light List Accent 5"/>
- <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 5"/>
- <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 5"/>
- <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 5"/>
- <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 5"/>
- <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 5"/>
- <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 5"/>
- <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 5"/>
- <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 5"/>
- <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 5"/>
- <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 5"/>
- <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 5"/>
- <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 5"/>
- <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 6"/>
- <w:LsdException Locked="false" Priority="61" Name="Light List Accent 6"/>
- <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 6"/>
- <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 6"/>
- <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 6"/>
- <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 6"/>
- <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 6"/>
- <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 6"/>
- <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 6"/>
- <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 6"/>
- <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 6"/>
- <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 6"/>
- <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 6"/>
- <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 6"/>
- <w:LsdException Locked="false" Priority="19" QFormat="true" Name="Subtle Emphasis"/>
- <w:LsdException Locked="false" Priority="21" QFormat="true" Name="Intense Emphasis"/>
- <w:LsdException Locked="false" Priority="31" QFormat="true" Name="Subtle Reference"/>
- <w:LsdException Locked="false" Priority="32" QFormat="true" Name="Intense Reference"/>
- <w:LsdException Locked="false" Priority="33" QFormat="true" Name="Book Title"/>
- <w:LsdException Locked="false" Priority="37" SemiHidden="true" UnhideWhenUsed="true" Name="Bibliography"/>
- <w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="TOC Heading"/>
- <w:LsdException Locked="false" Priority="41" Name="Plain Table 1"/>
- <w:LsdException Locked="false" Priority="42" Name="Plain Table 2"/>
- <w:LsdException Locked="false" Priority="43" Name="Plain Table 3"/>
- <w:LsdException Locked="false" Priority="44" Name="Plain Table 4"/>
- <w:LsdException Locked="false" Priority="45" Name="Plain Table 5"/>
- <w:LsdException Locked="false" Priority="40" Name="Grid Table Light"/>
- <w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light"/>
- <w:LsdException Locked="false" Priority="47" Name="Grid Table 2"/>
- <w:LsdException Locked="false" Priority="48" Name="Grid Table 3"/>
- <w:LsdException Locked="false" Priority="49" Name="Grid Table 4"/>
- <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark"/>
- <w:LsdException Locked="false" Priority="51" Name="Grid Table 6 C
- olorful"/>
- <w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful"/>
- <w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 1"/>
- <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 1"/>
- <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 1"/>
- <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 1"/>
- <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 1"/>
- <w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 1"/>
- <w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 1"/>
- <w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 2"/>
- <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 2"/>
- <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 2"/>
- <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 2"/>
- <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 2"/>
- <w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 2"/>
- <w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 2"/>
- <w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 3"/>
- <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 3"/>
- <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 3"/>
- <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 3"/>
- <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 3"/>
- <w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 3"/>
- <w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 3"/>
- <w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 4"/>
- <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 4"/>
- <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 4"/>
- <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 4"/>
- <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 4"/>
- <w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 4"/>
- <w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 4"/>
- <w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 5"/>
- <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 5"/>
- <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 5"/>
- <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 5"/>
- <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 5"/>
- <w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 5"/>
- <w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 5"/>
- <w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 6"/>
- <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 6"/>
- <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 6"/>
- <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 6"/>
- <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 6"/>
- <w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 6"/>
- <w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 6"/>
- <w:LsdException Locked="false" Priority="46" Name="List Table 1 Light"/>
- <w:LsdException Locked="false" Priority="47" Name="List Table 2"/>
- <w:LsdException Locked="false" Priority="48" Name="List Table 3"/>
- <w:LsdException Locked="false" Priority="49" Name="List Table 4"/>
- <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark"/>
- <w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful"/>
- <w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful"/>
- <w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 1"/>
- <w:LsdExcep
- tion Locked="false" Priority="47" Name="List Table 2 Accent 1"/>
- <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 1"/>
- <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 1"/>
- <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 1"/>
- <w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 1"/>
- <w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 1"/>
- <w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 2"/>
- <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 2"/>
- <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 2"/>
- <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 2"/>
- <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 2"/>
- <w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 2"/>
- <w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 2"/>
- <w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 3"/>
- <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 3"/>
- <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 3"/>
- <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 3"/>
- <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 3"/>
- <w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 3"/>
- <w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 3"/>
- <w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 4"/>
- <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 4"/>
- <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 4"/>
- <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 4"/>
- <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 4"/>
- <w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 4"/>
- <w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 4"/>
- <w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 5"/>
- <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 5"/>
- <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 5"/>
- <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 5"/>
- <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 5"/>
- <w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 5"/>
- <w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 5"/>
- <w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 6"/>
- <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 6"/>
- <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 6"/>
- <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 6"/>
- <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 6"/>
- <w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 6"/>
- <w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 6"/>
- </w:LatentStyles>
- </xml><![endif]-->
- <style>
- <!--
- /* Font Definitions */
- @font-face
- 	 {font-family:宋体;
- 	 panose-1:2 1 6 0 3 1 1 1 1 1;
- 	 mso-font-alt:SimSun;
- 	 mso-font-charset:134;
- 	 mso-generic-font-family:auto;
- 	 mso-font-pitch:variable;
- 	 mso-font-signature:3 680460288 22 0 262145 0;}
- @font-face
- 	 {font-family:"Cambria Math";
- 	 panose-1:2 4 5 3 5 4 6 3 2 4;
- 	 mso-font-charset:1;
- 	 mso-generic-font-family:roman;
- 	 mso-font-pitch:variable;
- 	 mso-font-signature:0 0 0 0 0 0;}
- @font-face
- 	 {font-family:等线;
- 	 panose-1:2 1 6 0 3 1 1 1 1 1;
- 	 mso-font-alt:DengXian;
- 	 mso-font-charset:134;
- 	 mso-generic-font-family:auto;
- 	 mso-font-pitch:variable;
- 	 mso-font-signature:-1610612033 953122042 22 0 262159 0;}
- @font-face
- 	 {font-family:微软雅黑;
- 	 panose-1:2 11 5 3 2 2 4 2 2 4;
- 	 mso-font-charset:134;
- 	 mso-generic-font-family:swiss;
- 	 mso-font-pitch:variable;
- 	 mso-font-signature:-2147483001 718224464 22 0 262175 0;}
- @font-face
- 	 {font-family:"
- 	 mso-font-charset:134;
- 	 mso-generic-font-family:swiss;
- 	 mso-font-pitch:variable;
- 	 mso-font-signature:-2147483001 718224464 22 0 262175 0;}
- @font-face
- 	 {font-family:"
- 	 panose-1:2 1 6 0 3 1 1 1 1 1;
- 	 mso-font-charset:134;
- 	 mso-generic-font-family:auto;
- 	 mso-font-pitch:variable;
- 	 mso-font-signature:3 680460288 22 0 262145 0;}
- @font-face
- 	 {font-family:"
- 	 panose-1:2 1 6 0 3 1 1 1 1 1;
- 	 mso-font-charset:134;
- 	 mso-generic-font-family:auto;
- 	 mso-font-pitch:variable;
- 	 mso-font-signature:-1610612033 953122042 22 0 262159 0;}
- /* Style Definitions */
- p.MsoNormal, li.MsoNormal, div.MsoNormal
- 	 {mso-style-unhide:no;
- 	 mso-style-qformat:yes;
- 	 mso-style-parent:"";
- 	 margin:0cm;
- 	 margin-bottom:.0001pt;
- 	 text-align:justify;
- 	 text-justify:inter-ideograph;
- 	 line-height:110%;
- 	 mso-pagination:widow-orphan;
- 	 font-size:10.5pt;
- 	 mso-bidi-font-size:11.0pt;
- 	 font-family:等线;
- 	 mso-ascii-font-family:等线;
- 	 mso-ascii-theme-font:minor-latin;
- 	 mso-fareast-font-family:等线;
- 	 mso-fareast-theme-font:minor-fareast;
- 	 mso-hansi-font-family:等线;
- 	 mso-hansi-theme-font:minor-latin;
- 	 mso-bidi-font-family:"Times New Roman";
- 	 mso-bidi-theme-font:minor-bidi;
- 	 mso-font-kerning:1.0pt;}
- a:link, span.MsoHyperlink
- 	 {mso-style-noshow:yes;
- 	 mso-style-priority:99;
- 	 color:#0563C1;
- 	 mso-themecolor:hyperlink;
- 	 text-decoration:underline;
- 	 text-underline:single;}
- a:visited, span.MsoHyperlinkFollowed
- 	 {mso-style-noshow:yes;
- 	 mso-style-priority:99;
- 	 color:#954F72;
- 	 mso-themecolor:followedhyperlink;
- 	 text-decoration:underline;
- 	 text-underline:single;}
- p.msonormal0, li.msonormal0, div.msonormal0
- 	 {mso-style-name:msonormal;
- 	 mso-style-unhide:no;
- 	 mso-margin-top-alt:auto;
- 	 margin-right:0cm;
- 	 mso-margin-bottom-alt:auto;
- 	 margin-left:0cm;
- 	 mso-pagination:widow-orphan;
- 	 font-size:12.0pt;
- 	 font-family:宋体;
- 	 mso-bidi-font-family:宋体;}
- span.EmailStyle18
- 	 {mso-style-type:personal-compose;
- 	 mso-style-noshow:yes;
- 	 mso-style-unhide:no;
- 	 mso-ansi-font-size:11.0pt;
- 	 mso-bidi-font-size:11.0pt;
- 	 font-family:"Times New Roman",serif;
- 	 mso-ascii-font-family:"Times New Roman";
- 	 mso-fareast-font-family:微软雅黑;
- 	 mso-hansi-font-family:"Times New Roman";
- 	 mso-bidi-font-family:"Times New Roman";
- 	 mso-bidi-theme-font:minor-bidi;
- 	 color:windowtext;
- 	 font-weight:normal;
- 	 font-style:normal;}
- .MsoChpDefault
- 	 {mso-style-type:export-only;
- 	 mso-default-props:yes;
- 	 font-size:10.0pt;
- 	 mso-ansi-font-size:10.0pt;
- 	 mso-bidi-font-size:10.0pt;
- 	 font-family:等线;
- 	 mso-ascii-font-family:等线;
- 	 mso-fareast-font-family:等线;
- 	 mso-hansi-font-family:等线;
- 	 mso-bidi-font-family:"Times New Roman";
- 	 mso-bidi-theme-font:minor-bidi;
- 	 mso-font-kerning:0pt;}
- /* Page Definitions */
- @page
- 	 {mso-page-border-surround-header:no;
- 	 mso-page-border-surround-footer:no;}
- @page WordSection1
- 	 {size:612.0pt 792.0pt;
- 	 margin:72.0pt 90.0pt 72.0pt 90.0pt;
- 	 mso-header-margin:36.0pt;
- 	 mso-footer-margin:36.0pt;
- 	 mso-paper-source:0;}
- div.WordSection1
- 	 {page:WordSection1;}
- -->
- </style>
- <!--[if gte mso 10]><style>/* Style Definitions */
- table.MsoNormalTable
- 	 {mso-style-name:普通表格;
- 	 mso-tstyle-rowband-size:0;
- 	 mso-tstyle-colband-size:0;
- 	 mso-style-noshow:yes;
- 	 mso-style-priority:99;
- 	 mso-style-parent:"";
- 	 mso-padding-alt:0cm 5.4pt 0cm 5.4pt;
- 	 mso-para-margin:0cm;
- 	 mso-para-margin-bottom:.0001pt;
- 	 mso-pagination:widow-orphan;
- 	 font-size:10.0pt;
- 	 font
- -family:等线;}
- </style><![endif]-->
- <!--[if gte mso 9]><xml>
- <o:shapedefaults v:ext="edit" spidmax="1026" />
- </xml><![endif]-->
- <!--[if gte mso 9]><xml>
- <o:shapelayout v:ext="edit">
- <o:idmap v:ext="edit" data="1" />
- </o:shapelayout></xml><![endif]-->
- </head>
- <body lang=ZH-CN link="#0563C1" vlink="#954F72" style='tab-interval:21.0pt;text-justify-trim:punctuation'>
- <div class=WordSection1>  
- <p class=MsoNormal>  
- <span lang=EN-US style='font-size:11.0pt;line-height:110%;font-family:"Times New Roman",serif;mso-fareast-font-family:微软雅黑;mso-bidi-font-family:"Times New Roman";mso-bidi-theme-font:minor-bidi'>   
- <o:p>
-&nbsp;
- </o:p>
- </span>  
-
-
- </p>
- <p class=MsoNormal>  
- <span lang=EN-US style='font-size:11.0pt;line-height:110%;font-family:"Times New Roman",serif;mso-fareast-font-family:微软雅黑;mso-bidi-font-family:"Times New Roman";mso-bidi-theme-font:minor-bidi'>   
- <o:p>
-&nbsp;
- </o:p>
- </span>  
-
-
- </p>
- <p class=MsoNormal>  
- <a name="_MailAutoSig">   
- <b>   
- <span lang=EN-US style='font-family:"微软雅黑",sans-serif;color:black'>  Dears
- </span>  
- </b>     
- </a>
- <span style='mso-bookmark:_MailAutoSig'>  
- <b>   
- <span style='font-family:"微软雅黑",sans-serif;color:black'>  ：
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </b>  
- </span>  
-
-
- </p>
- <p class=MsoNormal>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <b>   
- <span lang=EN-US style='font-family:"微软雅黑",sans-serif;color:black'>  
-&nbsp;
-&nbsp;
-&nbsp;
-&nbsp;
-&nbsp; 
- </span>  
- </b>  
- </span>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <b>   
- <span style='font-family:"微软雅黑",sans-serif;color:black'>  经过汇总 大家提前合理安排进房间入住吧。
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </b>  
- </span>  
-
-
- </p>
- <p class=MsoNormal>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='mso-ascii-font-family:等线;mso-fareast-font-family:等线;mso-hansi-font-family:等线;color:black'>  
- <o:p>
-&nbsp;
- </o:p>
- </span>  
- </span>  
-
-
- </p>
- <table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=227 style='width:6.0cm;margin-left:-.4pt;border-collapse:collapse;mso-yfti-tbllook:1184;mso-padding-alt:0cm 0cm 0cm 0cm'> 
-   
- <tr style='mso-yfti-irow:0;mso-yfti-firstrow:yes;height:14.25pt'>  
- <td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  房型
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
- <td width=142 nowrap style='width:106.3pt;border:solid windowtext 1.0pt;border-left:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  时间段
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
-
- </tr>
- <tr style='mso-yfti-irow:1;height:14.25pt'>  
- <td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  迷你房
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
- <td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  全天
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
-
- </tr>
- <tr style='mso-yfti-irow:2;height:14.25pt'>  
- <td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  大床房
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
- <td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='font-size:11.0pt;line-height:110%;color:black'>  9:00-12:00
- <o:p>
- </o:p>
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
-
- </tr>
- <tr style='mso-yfti-irow:3;height:14.25pt'>  
- <td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  小床房
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
- <td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='font-size:11.0pt;line-height:110%;color:black'>  1:00-15:30
- <o:p>
- </o:p>
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
-
- </tr>
- <tr style='mso-yfti-irow:4;height:14.25pt'>  
- <td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  标准房
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
- <td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='font-size:11.0pt;line-height:110%;color:black'>  15:30-18:00
- <o:p>
- </o:p>
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
-
- </tr>
- <tr style='mso-yfti-irow:5;height:14.25pt'>  
- <td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  三床房
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
- <td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  全天
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
-
- </tr>
- <tr style='mso-yfti-irow:6;mso-yfti-lastrow:yes;height:14.25pt'>  
- <td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  四床房
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
- <td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'>  
- <p class=MsoNormal align=left style='text-align:left'>   
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='font-size:11.0pt;line-height:110%;color:black'>  全天
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>    
-
-
- </p>
- </td>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
-
- </tr>
- </table>  
- <p class=MsoNormal style='line-height:normal;mso-pagination:none'>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>   
- <o:p>
-&nbsp;
- </o:p>
- </span>  
- </span>  
-
-
- </p>
- <p class=MsoNormal style='line-height:normal;mso-pagination:none'>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>   
- <o:p>
-&nbsp;
- </o:p>
- </span>  
- </span>  
-
-
- </p>
- <p class=MsoNormal style='line-height:normal;mso-pagination:none'>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>   Best Regards
- <o:p>
- </o:p>
- </span>  
- </span>  
-
-
- </p>
- <p class=MsoNormal style='line-height:normal;mso-pagination:none'>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>   Tha
- </span>  
- </span>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>   你
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>  
-
-
- </p>
- <p class=MsoNormal style='line-height:normal;mso-pagination:none'>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>   ---------------------------------
- <o:p>
- </o:p>
- </span>  
- </span>  
-
-
- </p>
- <p class=MsoNormal style='line-height:normal;mso-pagination:none'>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>   郝竹林
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>  
-
-
- </p>
- <p class=MsoNormal style='line-height:normal;mso-pagination:none'>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>   Seat: 15#3F093 | TEL: 737057
- <o:p>
- </o:p>
- </span>  
- </span>  
-
-
- </p>
- <p class=MsoNormal style='line-height:normal;mso-pagination:none'>  
- <span style='mso-bookmark:_MailAutoSig'>  
- <span style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>   酒店研发部
- <span lang=EN-US>  
- <o:p>
- </o:p>
- </span>  
- </span>  
- </span>  
-
-
- </p>  
- <span style='mso-bookmark:_MailAutoSig'>  
- </span>  
- <p class=MsoNormal>
- <span lang=EN-US>  
- <o:p>
-&nbsp;
- </o:p>
- </span>  
-
-
- </p>
- </div>  
- </body>
- </html>
+<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head><meta name=ProgId content=Word.Document><meta name=Generator content="Microsoft Word 15"><meta name=Originator content="Microsoft Word 15"><link rel=File-List href="cid:filelist.xml@01D435C0.4C83B540"><!--[if gte mso 9]><xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+</o:OfficeDocumentSettings>
+</xml><![endif]--><link rel=themeData href="~~themedata~~"><link rel=colorSchemeMapping href="~~colorschememapping~~"><!--[if gte mso 9]><xml>
+<w:WordDocument>
+<w:SpellingState>Clean</w:SpellingState>
+<w:TrackMoves/>
+<w:TrackFormatting/>
+<w:EnvelopeVis/>
+<w:PunctuationKerning/>
+<w:DrawingGridVerticalSpacing>7.8 磅</w:DrawingGridVerticalSpacing>
+<w:DisplayHorizontalDrawingGridEvery>0</w:DisplayHorizontalDrawingGridEvery>
+<w:DisplayVerticalDrawingGridEvery>2</w:DisplayVerticalDrawingGridEvery>
+<w:ValidateAgainstSchemas/>
+<w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>
+<w:IgnoreMixedContent>false</w:IgnoreMixedContent>
+<w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>
+<w:DoNotPromoteQF/>
+<w:LidThemeOther>EN-US</w:LidThemeOther>
+<w:LidThemeAsian>ZH-CN</w:LidThemeAsian>
+<w:LidThemeComplexScript>X-NONE</w:LidThemeComplexScript>
+<w:Compatibility>
+<w:SpaceForUL/>
+<w:BalanceSingleByteDoubleByteWidth/>
+<w:DoNotLeaveBackslashAlone/>
+<w:ULTrailSpace/>
+<w:DoNotExpandShiftReturn/>
+<w:AdjustLineHeightInTable/>
+<w:BreakWrappedTables/>
+<w:SnapToGridInCell/>
+<w:WrapTextWithPunct/>
+<w:UseAsianBreakRules/>
+<w:DontGrowAutofit/>
+<w:SplitPgBreakAndParaMark/>
+<w:EnableOpenTypeKerning/>
+<w:DontFlipMirrorIndents/>
+<w:OverrideTableStyleHps/>
+<w:UseFELayout/>
+</w:Compatibility>
+<w:BrowserLevel>MicrosoftInternetExplorer4</w:BrowserLevel>
+<m:mathPr>
+<m:mathFont m:val="Cambria Math"/>
+<m:brkBin m:val="before"/>
+<m:brkBinSub m:val="&#45;-"/>
+<m:smallFrac m:val="off"/>
+<m:dispDef/>
+<m:lMargin m:val="0"/>
+<m:rMargin m:val="0"/>
+<m:defJc m:val="centerGroup"/>
+<m:wrapIndent m:val="1440"/>
+<m:intLim m:val="subSup"/>
+<m:naryLim m:val="undOvr"/>
+</m:mathPr></w:WordDocument>
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<w:LatentStyles DefLockedState="false" DefUnhideWhenUsed="false" DefSemiHidden="false" DefQFormat="false" DefPriority="99" LatentStyleCount="371">
+<w:LsdException Locked="false" Priority="0" QFormat="true" Name="Normal"/>
+<w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 1"/>
+<w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 2"/>
+<w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 3"/>
+<w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 4"/>
+<w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 5"/>
+<w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 6"/>
+<w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 7"/>
+<w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 8"/>
+<w:LsdException Locked="false" Priority="9" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="heading 9"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 4"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 5"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 6"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 7"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 8"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index 9"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 1"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 2"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 3"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 4"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 5"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 6"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 7"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 8"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" Name="toc 9"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Normal Indent"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="footnote text"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="annotation text"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="header"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="footer"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="index heading"/>
+<w:LsdException Locked="false" Priority="35" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="caption"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="table of figures"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="envelope address"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="envelope return"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="footnote reference"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="annotation reference"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="line number"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="page number"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="endnote reference"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="endnote text"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="table of authorities"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="macro"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="toa heading"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List 4"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List 5"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet 4"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Bullet 5"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number 4"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Number 5"/>
+<w:LsdException Locked="false" Priority="10" QFormat="true" Name="Title"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Closing"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Signature"/>
+<w:LsdException Locked="false" Priority="1" SemiHidden="true" UnhideWhenUsed="true" Name="Default Paragraph Font"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text Indent"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue 4"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="List Continue 5"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Message Header"/>
+<w:LsdException Locked="false" Priority="11" QFormat="true" Name="Subtitle"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Salutation"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Date"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text First Indent"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text First Indent 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Note Heading"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text Indent 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Body Text Indent 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Block Text"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Hyperlink"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="FollowedHyperlink"/>
+<w:LsdException Locked="false" Priority="22" QFormat="true" Name="Strong"/>
+<w:LsdException Locked="false" Priority="20" QFormat="true" Name="Emphasis"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Document Map"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Plain Text"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="E-mail Signature"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Top of Form"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Bottom of Form"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Normal (Web)"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Acronym"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Address"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Cite"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Code"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Definition"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Keyboard"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Preformatted"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Sample"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Typewriter"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="HTML Variable"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Normal Table"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="annotation subject"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="No List"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Outline List 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Outline List 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Outline List 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Simple 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Simple 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Simple 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Classic 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Classic 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Classic 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Classic 4"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Colorful 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Colorful 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Colorful 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 4"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Columns 5"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 4"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 5"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 6"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 7"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Grid 8"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 4"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 5"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 6"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 7"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table List 8"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table 3D effects 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table 3D effects 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table 3D effects 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Contemporary"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Elegant"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Professional"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Subtle 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Subtle 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Web 1"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Web 2"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Web 3"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Balloon Text"/>
+<w:LsdException Locked="false" Priority="39" Name="Table Grid"/>
+<w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true" Name="Table Theme"/>
+<w:LsdException Locked="false" SemiHidden="true" Name="Placeholder Text"/>
+<w:LsdException Locked="false" Priority="1" QFormat="true" Name="No Spacing"/>
+<w:LsdException Locked="false" Priority="60" Name="Light Shading"/>
+<w:LsdException Locked="false" Priority="61" Name="Light List"/>
+<w:LsdException Locked="false" Priority="62" Name="Light Grid"/>
+<w:LsdException Locked="false" Priority="63" Name="Medium Shading 1"/>
+<w:LsdException Locked="false" Priority="64" Name="Medium Shading 2"/>
+<w:LsdException Locked="false" Priority="65" Name="Medium List 1"/>
+<w:LsdException Locked="false" Priority="66" Name="Medium List 2"/>
+<w:LsdException Locked="false" Priority="67" Name="Medium Grid 1"/>
+<w:LsdException Locked="false" Priority="68" Name="Medium Grid 2"/>
+<w:LsdException Locked="false" Priority="69" Name="Medium Grid 3"/>
+<w:LsdException Locked="false" Priority="70" Name="Dark List"/>
+<w:LsdException Locked="false" Priority="71" Name="Colorful Shading"/>
+<w:LsdException Locked="false" Priority="72" Name="Colorful List"/>
+<w:LsdException Locked="false" Priority="73" Name="Colorful Grid"/>
+<w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 1"/>
+<w:LsdException Locked="false" Priority="61" Name="Light List Accent 1"/>
+<w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 1"/>
+<w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 1"/>
+<w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 1"/>
+<w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 1"/>
+<w:LsdException Locked="false" SemiHidden="true" Name="Revision"/>
+<w:LsdException Locked="false" Priority="34" QFormat="true" Name="List Paragraph"/>
+<w:LsdException Locked="false" Priority="29" QFormat="true" Name="Quote"/>
+<w:LsdException Locked="false" Priority="30" QFormat="true" Name="Intense Quote"/>
+<w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 1"/>
+<w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 1"/>
+<w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 1"/>
+<w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 1"/>
+<w:LsdException Locked="false" Priority="70" Name="Dark List Accent 1"/>
+<w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 1"/>
+<w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 1"/>
+<w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 1"/>
+<w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 2"/>
+<w:LsdException Locked="false" Priority="61" Name="Light List Accent 2"/>
+<w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 2"/>
+<w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 2"/>
+<w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 2"/>
+<w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 2"/>
+<w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 2"/>
+<w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 2"/>
+<w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 2"/>
+<w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 2"/>
+<w:LsdException Locked="false" Priority="70" Name="Dark List Accent 2"/>
+<w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 2"/>
+<w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 2"/>
+<w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 2"/>
+<w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 3"/>
+<w:LsdException Locked="false" Priority="61" Name="Light List Accent 3"/>
+<w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 3"/>
+<w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 3"/>
+<w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 3"/>
+<w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 3"/>
+<w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 3"/>
+<w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 3"/>
+<w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 3"/>
+<w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 3"/>
+<w:LsdException Locked="false" Priority="70" Name="Dark List Accent 3"/>
+<w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 3"/>
+<w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 3"/>
+<w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 3"/>
+<w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 4"/>
+<w:LsdException Locked="false" Priority="61" Name="Light List Accent 4"/>
+<w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 4"/>
+<w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 4"/>
+<w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 4"/>
+<w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 4"/>
+<w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 4"/>
+<w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 4"/>
+<w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 4"/>
+<w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 4"/>
+<w:LsdException Locked="false" Priority="70" Name="Dark List Accent 4"/>
+<w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 4"/>
+<w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 4"/>
+<w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 4"/>
+<w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 5"/>
+<w:LsdException Locked="false" Priority="61" Name="Light List Accent 5"/>
+<w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 5"/>
+<w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 5"/>
+<w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 5"/>
+<w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 5"/>
+<w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 5"/>
+<w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 5"/>
+<w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 5"/>
+<w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 5"/>
+<w:LsdException Locked="false" Priority="70" Name="Dark List Accent 5"/>
+<w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 5"/>
+<w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 5"/>
+<w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 5"/>
+<w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 6"/>
+<w:LsdException Locked="false" Priority="61" Name="Light List Accent 6"/>
+<w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 6"/>
+<w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 6"/>
+<w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 6"/>
+<w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 6"/>
+<w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 6"/>
+<w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 6"/>
+<w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 6"/>
+<w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 6"/>
+<w:LsdException Locked="false" Priority="70" Name="Dark List Accent 6"/>
+<w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 6"/>
+<w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 6"/>
+<w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 6"/>
+<w:LsdException Locked="false" Priority="19" QFormat="true" Name="Subtle Emphasis"/>
+<w:LsdException Locked="false" Priority="21" QFormat="true" Name="Intense Emphasis"/>
+<w:LsdException Locked="false" Priority="31" QFormat="true" Name="Subtle Reference"/>
+<w:LsdException Locked="false" Priority="32" QFormat="true" Name="Intense Reference"/>
+<w:LsdException Locked="false" Priority="33" QFormat="true" Name="Book Title"/>
+<w:LsdException Locked="false" Priority="37" SemiHidden="true" UnhideWhenUsed="true" Name="Bibliography"/>
+<w:LsdException Locked="false" Priority="39" SemiHidden="true" UnhideWhenUsed="true" QFormat="true" Name="TOC Heading"/>
+<w:LsdException Locked="false" Priority="41" Name="Plain Table 1"/>
+<w:LsdException Locked="false" Priority="42" Name="Plain Table 2"/>
+<w:LsdException Locked="false" Priority="43" Name="Plain Table 3"/>
+<w:LsdException Locked="false" Priority="44" Name="Plain Table 4"/>
+<w:LsdException Locked="false" Priority="45" Name="Plain Table 5"/>
+<w:LsdException Locked="false" Priority="40" Name="Grid Table Light"/>
+<w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light"/>
+<w:LsdException Locked="false" Priority="47" Name="Grid Table 2"/>
+<w:LsdException Locked="false" Priority="48" Name="Grid Table 3"/>
+<w:LsdException Locked="false" Priority="49" Name="Grid Table 4"/>
+<w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark"/>
+<w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful"/>
+<w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful"/>
+<w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 1"/>
+<w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 1"/>
+<w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 1"/>
+<w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 1"/>
+<w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 1"/>
+<w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 1"/>
+<w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 1"/>
+<w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 2"/>
+<w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 2"/>
+<w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 2"/>
+<w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 2"/>
+<w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 2"/>
+<w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 2"/>
+<w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 2"/>
+<w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 3"/>
+<w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 3"/>
+<w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 3"/>
+<w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 3"/>
+<w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 3"/>
+<w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 3"/>
+<w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 3"/>
+<w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 4"/>
+<w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 4"/>
+<w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 4"/>
+<w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 4"/>
+<w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 4"/>
+<w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 4"/>
+<w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 4"/>
+<w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 5"/>
+<w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 5"/>
+<w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 5"/>
+<w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 5"/>
+<w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 5"/>
+<w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 5"/>
+<w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 5"/>
+<w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light Accent 6"/>
+<w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 6"/>
+<w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 6"/>
+<w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 6"/>
+<w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 6"/>
+<w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful Accent 6"/>
+<w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful Accent 6"/>
+<w:LsdException Locked="false" Priority="46" Name="List Table 1 Light"/>
+<w:LsdException Locked="false" Priority="47" Name="List Table 2"/>
+<w:LsdException Locked="false" Priority="48" Name="List Table 3"/>
+<w:LsdException Locked="false" Priority="49" Name="List Table 4"/>
+<w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark"/>
+<w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful"/>
+<w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful"/>
+<w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 1"/>
+<w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 1"/>
+<w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 1"/>
+<w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 1"/>
+<w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 1"/>
+<w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 1"/>
+<w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 1"/>
+<w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 2"/>
+<w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 2"/>
+<w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 2"/>
+<w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 2"/>
+<w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 2"/>
+<w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 2"/>
+<w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 2"/>
+<w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 3"/>
+<w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 3"/>
+<w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 3"/>
+<w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 3"/>
+<w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 3"/>
+<w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 3"/>
+<w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 3"/>
+<w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 4"/>
+<w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 4"/>
+<w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 4"/>
+<w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 4"/>
+<w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 4"/>
+<w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 4"/>
+<w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 4"/>
+<w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 5"/>
+<w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 5"/>
+<w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 5"/>
+<w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 5"/>
+<w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 5"/>
+<w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 5"/>
+<w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 5"/>
+<w:LsdException Locked="false" Priority="46" Name="List Table 1 Light Accent 6"/>
+<w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 6"/>
+<w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 6"/>
+<w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 6"/>
+<w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 6"/>
+<w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful Accent 6"/>
+<w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful Accent 6"/>
+</w:LatentStyles>
+</xml><![endif]--><style><!--
+/* Font Definitions */
+@font-face
+	{font-family:宋体;
+	panose-1:2 1 6 0 3 1 1 1 1 1;
+	mso-font-alt:SimSun;
+	mso-font-charset:134;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:3 680460288 22 0 262145 0;}
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;
+	mso-font-charset:1;
+	mso-generic-font-family:roman;
+	mso-font-pitch:variable;
+	mso-font-signature:0 0 0 0 0 0;}
+@font-face
+	{font-family:等线;
+	panose-1:2 1 6 0 3 1 1 1 1 1;
+	mso-font-alt:DengXian;
+	mso-font-charset:134;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-1610612033 953122042 22 0 262159 0;}
+@font-face
+	{font-family:微软雅黑;
+	panose-1:2 11 5 3 2 2 4 2 2 4;
+	mso-font-charset:134;
+	mso-generic-font-family:swiss;
+	mso-font-pitch:variable;
+	mso-font-signature:-2147483001 718224464 22 0 262175 0;}
+@font-face
+	{font-family:"\@微软雅黑";
+	mso-font-charset:134;
+	mso-generic-font-family:swiss;
+	mso-font-pitch:variable;
+	mso-font-signature:-2147483001 718224464 22 0 262175 0;}
+@font-face
+	{font-family:"\@宋体";
+	panose-1:2 1 6 0 3 1 1 1 1 1;
+	mso-font-charset:134;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:3 680460288 22 0 262145 0;}
+@font-face
+	{font-family:"\@等线";
+	panose-1:2 1 6 0 3 1 1 1 1 1;
+	mso-font-charset:134;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-1610612033 953122042 22 0 262159 0;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-parent:"";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	text-align:justify;
+	text-justify:inter-ideograph;
+	line-height:110%;
+	mso-pagination:widow-orphan;
+	font-size:10.5pt;
+	mso-bidi-font-size:11.0pt;
+	font-family:等线;
+	mso-ascii-font-family:等线;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:等线;
+	mso-fareast-theme-font:minor-fareast;
+	mso-hansi-font-family:等线;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;
+	mso-font-kerning:1.0pt;}
+a:link, span.MsoHyperlink
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	color:#0563C1;
+	mso-themecolor:hyperlink;
+	text-decoration:underline;
+	text-underline:single;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	color:#954F72;
+	mso-themecolor:followedhyperlink;
+	text-decoration:underline;
+	text-underline:single;}
+p.msonormal0, li.msonormal0, div.msonormal0
+	{mso-style-name:msonormal;
+	mso-style-unhide:no;
+	mso-margin-top-alt:auto;
+	margin-right:0cm;
+	mso-margin-bottom-alt:auto;
+	margin-left:0cm;
+	mso-pagination:widow-orphan;
+	font-size:12.0pt;
+	font-family:宋体;
+	mso-bidi-font-family:宋体;}
+span.EmailStyle18
+	{mso-style-type:personal-compose;
+	mso-style-noshow:yes;
+	mso-style-unhide:no;
+	mso-ansi-font-size:11.0pt;
+	mso-bidi-font-size:11.0pt;
+	font-family:"Times New Roman",serif;
+	mso-ascii-font-family:"Times New Roman";
+	mso-fareast-font-family:微软雅黑;
+	mso-hansi-font-family:"Times New Roman";
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;
+	color:windowtext;
+	font-weight:normal;
+	font-style:normal;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	mso-default-props:yes;
+	font-size:10.0pt;
+	mso-ansi-font-size:10.0pt;
+	mso-bidi-font-size:10.0pt;
+	font-family:等线;
+	mso-ascii-font-family:等线;
+	mso-fareast-font-family:等线;
+	mso-hansi-font-family:等线;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;
+	mso-font-kerning:0pt;}
+/* Page Definitions */
+@page
+	{mso-page-border-surround-header:no;
+	mso-page-border-surround-footer:no;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 90.0pt 72.0pt 90.0pt;
+	mso-header-margin:36.0pt;
+	mso-footer-margin:36.0pt;
+	mso-paper-source:0;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 10]><style>/* Style Definitions */
+table.MsoNormalTable
+	{mso-style-name:普通表格;
+	mso-tstyle-rowband-size:0;
+	mso-tstyle-colband-size:0;
+	mso-style-noshow:yes;
+	mso-style-priority:99;
+	mso-style-parent:"";
+	mso-padding-alt:0cm 5.4pt 0cm 5.4pt;
+	mso-para-margin:0cm;
+	mso-para-margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+	font-size:10.0pt;
+	font-family:等线;}
+</style><![endif]--><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext="edit" spidmax="1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext="edit">
+<o:idmap v:ext="edit" data="1" />
+</o:shapelayout></xml><![endif]--></head><body lang=ZH-CN link="#0563C1" vlink="#954F72" style='tab-interval:21.0pt;text-justify-trim:punctuation'><div class=WordSection1><p class=MsoNormal><span lang=EN-US style='font-size:11.0pt;line-height:110%;font-family:"Times New Roman",serif;mso-fareast-font-family:微软雅黑;mso-bidi-font-family:"Times New Roman";mso-bidi-theme-font:minor-bidi'><o:p>&nbsp;</o:p></span></p><p class=MsoNormal><span lang=EN-US style='font-size:11.0pt;line-height:110%;font-family:"Times New Roman",serif;mso-fareast-font-family:微软雅黑;mso-bidi-font-family:"Times New Roman";mso-bidi-theme-font:minor-bidi'><o:p>&nbsp;</o:p></span></p><p class=MsoNormal><a name="_MailAutoSig"><b><span lang=EN-US style='font-family:"微软雅黑",sans-serif;color:black'>Dears</span></b></a><span style='mso-bookmark:_MailAutoSig'><b><span style='font-family:"微软雅黑",sans-serif;color:black'>：<span lang=EN-US><o:p></o:p></span></span></b></span></p><p class=MsoNormal><span style='mso-bookmark:_MailAutoSig'><b><span lang=EN-US style='font-family:"微软雅黑",sans-serif;color:black'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></b></span><span style='mso-bookmark:_MailAutoSig'><b><span style='font-family:"微软雅黑",sans-serif;color:black'>经过汇总 大家提前合理安排进房间入住吧。<span lang=EN-US><o:p></o:p></span></span></b></span></p><p class=MsoNormal><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='mso-ascii-font-family:等线;mso-fareast-font-family:等线;mso-hansi-font-family:等线;color:black'><o:p>&nbsp;</o:p></span></span></p><table class=MsoNormalTable border=0 cellspacing=0 cellpadding=0 width=227 style='width:6.0cm;margin-left:-.4pt;border-collapse:collapse;mso-yfti-tbllook:1184;mso-padding-alt:0cm 0cm 0cm 0cm'><tr style='mso-yfti-irow:0;mso-yfti-firstrow:yes;height:14.25pt'><td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>房型<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span><td width=142 nowrap style='width:106.3pt;border:solid windowtext 1.0pt;border-left:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>时间段<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span></tr><tr style='mso-yfti-irow:1;height:14.25pt'><td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>迷你房<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span><td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>全天<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span></tr><tr style='mso-yfti-irow:2;height:14.25pt'><td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>大床房<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span><td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='font-size:11.0pt;line-height:110%;color:black'>9:00-12:00<o:p></o:p></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span></tr><tr style='mso-yfti-irow:3;height:14.25pt'><td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>小床房<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span><td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='font-size:11.0pt;line-height:110%;color:black'>1:00-15:30<o:p></o:p></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span></tr><tr style='mso-yfti-irow:4;height:14.25pt'><td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>标准房<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span><td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='font-size:11.0pt;line-height:110%;color:black'>15:30-18:00<o:p></o:p></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span></tr><tr style='mso-yfti-irow:5;height:14.25pt'><td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>三床房<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span><td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>全天<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span></tr><tr style='mso-yfti-irow:6;mso-yfti-lastrow:yes;height:14.25pt'><td width=85 nowrap style='width:63.8pt;border:solid windowtext 1.0pt;border-top:none;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>四床房<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span><td width=142 nowrap style='width:106.3pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;height:14.25pt'><p class=MsoNormal align=left style='text-align:left'><span style='mso-bookmark:_MailAutoSig'><span style='font-size:11.0pt;line-height:110%;color:black'>全天<span lang=EN-US><o:p></o:p></span></span></span></p></td><span style='mso-bookmark:_MailAutoSig'></span></tr></table><p class=MsoNormal style='line-height:normal;mso-pagination:none'><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'><o:p>&nbsp;</o:p></span></span></p><p class=MsoNormal style='line-height:normal;mso-pagination:none'><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'><o:p>&nbsp;</o:p></span></span></p><p class=MsoNormal style='line-height:normal;mso-pagination:none'><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>Best Regards<o:p></o:p></span></span></p><p class=MsoNormal style='line-height:normal;mso-pagination:none'><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>Tha</span></span><span style='mso-bookmark:_MailAutoSig'><span style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>你<span lang=EN-US><o:p></o:p></span></span></span></p><p class=MsoNormal style='line-height:normal;mso-pagination:none'><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>---------------------------------<o:p></o:p></span></span></p><p class=MsoNormal style='line-height:normal;mso-pagination:none'><span style='mso-bookmark:_MailAutoSig'><span style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>郝竹林<span lang=EN-US><o:p></o:p></span></span></span></p><p class=MsoNormal style='line-height:normal;mso-pagination:none'><span style='mso-bookmark:_MailAutoSig'><span lang=EN-US style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>Seat: 15#3F093 | TEL: 737057<o:p></o:p></span></span></p><p class=MsoNormal style='line-height:normal;mso-pagination:none'><span style='mso-bookmark:_MailAutoSig'><span style='mso-bidi-font-size:10.5pt;font-family:"微软雅黑",sans-serif;mso-no-proof:yes'>酒店研发部<span lang=EN-US><o:p></o:p></span></span></span></p><span style='mso-bookmark:_MailAutoSig'></span><p class=MsoNormal><span lang=EN-US><o:p>&nbsp;</o:p></span></p></div></body></html>

--- a/src/test/resources/test-messages/rtf-to-html-input.rtf
+++ b/src/test/resources/test-messages/rtf-to-html-input.rtf
@@ -1,0 +1,746 @@
+{\rtf1\ansi\ansicpg1251\fromhtml1 \fbidis \deff0{\fonttbl
+
+{\f0\fswiss\fcharset204 Arial;}
+
+{\f1\fmodern Courier New;}
+
+{\f2\fnil\fcharset2 Symbol;}
+
+{\f3\fmodern\fcharset0 Courier New;}}
+
+{\colortbl\red0\green0\blue0;\red0\green0\blue255;}
+
+\uc1\pard\plain\deftab360 \f0\fs24 
+
+{\*\htmltag243 <!DOCTYPE html>}
+
+{\*\htmltag3 \par }
+
+{\*\htmltag19 <html lang="en" style="margin: 0;padding: 0;font-family: arial, sans-serif;">}\htmlrtf \lang9 \htmlrtf0 
+
+{\*\htmltag2 \par }
+
+{\*\htmltag34 <head>}
+
+{\*\htmltag1 \par }
+
+{\*\htmltag241   }
+
+{\*\htmltag1 \par }
+
+{\*\htmltag241   }
+
+{\*\htmltag241 <style type="text/css">}
+
+{\*\htmltag241 \par     html,\par     body \{\par       margin: 0;\par       padding: 0;\par       font-family: arial, sans-serif;\par     \}\par     .letter \{\par       max-width: 680px;\par       margin: 0 auto;\par       font-family: arial, sans-serif;\par     \}\par \par     td,\par     .title,\par     .description \{\par       font-family: arial, sans-serif;\par     \}\par \par \par \par     .header \{\par       padding: 19px;\par       padding-bottom: 0;\par       background-color: #168de2;\par       text-align: center;\par     \}\par \par     .header .logo \{\par       float:right;\par     \}\par \par     .header .name \{\par       float: left;\par       margin: 0;\par       font-size: 20px;\par       color: #b3dfff;\par       line-height: 36px;\par     \}\par \par     .header .name strong \{\par       font-size: 20px;\par       font-weight: normal;\par       color: #ffffff;\par       text-align: center;\par       line-height: 28px;\par     \}\par \par     .header .title \{\par       clear: both;\par       margin: 0;\par       padding: 38px 0 25px;\par       font-size: 28px;\par       color: #ffffff;\par       text-align: center;\par       background-color: #168de2;\par     \}\par \par     .header .title_full \{\par       display: none;\par       overflow:hidden;\par       float:left;\par       line-height:0px;\par     \}\par \par     .header .title_short \{\par       display: block;\par       overflow: visible;\par       float: none;\par       line-height:100%;\par     \}\par \par     .header .description \{\par       font-size: 20px;\par       color: #b3dfff;\par       line-height: 28px;\par     \}\par \par     .header .description_full \{\par       display: block;\par       overflow: visible;\par       float: none;\par       line-height:28px;\par       background-color: #168de2;\par     \}\par \par     .lead-image img \{\par       vertical-align: top;\par     \}\par \par     .store \{\par       padding: 40px 20px;\par       text-align: center;\par         background-color: #ffde2a;\par     \}\par     .store .title \{\par       width: 160px;\par       font-size: 28px;\par       line-height: 32px;\par       margin-bottom: 0;\par       display: inline-block;\par       text-align: left;\par       vertical-align: top;\par     \}\par \par     .button-store \{\par       display: inline-block;\par       margin:0 8px;\par     \}\par \par     .button-store_android \{\par       width: 183px;\par       height: 64px;\par     \}\par \par     .button-store_apple \{\par       width: 183px;\par       height: 64px;\par     \}\par \par     .main \{\par       padding: 50px;\par     \}\par \par     .two-column \{\par       margin-bottom: 60px;\par     \}\par     .feature \{\par       width: 50%;\par       margin: 30px;\par       display: table-cell;\par     \}\par \par \par     .feature .icon,\par     .feature .title \{\par       display: table-cell;\par       vertical-align: middle;\par       text-align: left;\par     \}\par \par     .feature .title \{\par       padding-right: 20px;\par       font-size: 20px;\par       font-weight: bold;\par       line-height: 28px;\par     \}\par \par     .feature .icon \{\par       width: 48px;\par       padding-right: 20px;\par       padding-left: 20px;\par     \}\par \par     .feature .description \{\par       margin-top: 18px;\par       padding-left: 20px;\par       padding-right: 20px;\par       text-align: left;\par       font-size: 17px;\par       line-height: 24px;\par     \}\par \par     .main-feature \{\par       padding: 48px 19px 60px;\par       background: #f0f0f0;\par       text-align: center;\par       background-image: url(https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/pattern.png);\par       background-position: 50% 50%;\par       background-size: contain;\par       background-repeat: no-repeat;\par     \}\par \par     .main-feature .title \{\par       padding: 0 0 28px;\par       font-size: 28px;\par       color: #000000;\par       text-align: center;\par \par       line-height: 36px;\par     \}\par \par     .main-feature .description \{\par       padding: 44px 0 0;\par       font-size: 20px;\par       color: #000000;\par       text-align: center;\par       line-height: 28px;\par     \}\par \par     .main-feature .image \{\par       padding: 0 20px;\par     \}\par \par     .footer \{\par       margin: 48px 19px 60px;\par       text-align: center;\par     \}\par \par     .footer .title \{\par       margin-bottom: 24px;\par       font-size: 20px;\par       color: #323232;\par       line-height: 23px;\par     \}\par \par     .footer .description \{\par       font-size: 20px;\par       color: #999999;\par       line-height: 28px;\par     \}\par \par     .footer .service-links,\par     .footer .copy \{\par       font-size: 13px;\par       color: #999999;\par       line-height: 24px;\par     \}\par \par     .footer .social-links \{\par       margin-bottom: 34px;\par     \}\par \par     .footer .social-link \{\par       display: inline;\par       margin: 10px;\par     \}\par \par     .footer .separator \{\par       margin: 0 74px;\par       line-height: 1px;\par       border-bottom: 1px solid #999;\par     \}\par \par     .footer .logo \{\par       margin: 24px 0;\par     \}\par \par     .link \{\par       color: #005bd1;\par       text-decoration: none;\par     \}\par \par     .link:hover \{\par       text-decoration: underline;\par     \}\par \par \par     @media only screen and (max-width: 680px)  \{\par \par       .header \{\par         text-align: center !important;\par       \}\par       .header .logo \{\par         float: none !important;\par       \}\par \par       .header .name \{\par         float: none !important;\par         padding: 23px 0 21px !important;\par         text-align: center !important;\par         line-height: 28px !important;\par       \}\par       .header .title \{\par         padding: 0 0 12px !important;\par       \}\par       .header .title_full \{\par         display: block !important;\par         overflow: visible !important;\par         float: none !important;\par         line-height: 36px !important;\par       \}\par \par       .header .title_short \{\par         display: none !important;\par         overflow: hidden !important;\par         float: left !important;\par         line-height: 0px !important;\par       \}\par \par       .description_full \{\par         display: none !important;\par         overflow: hidden !important;\par         float: left !important;\par         line-height: 0px !important;\par       \}\par \par       .store .title \{\par         width: 115px  !important;\par         margin-bottom: 0 !important;\par         display: inline-block !important;\par         vertical-align: top !important;\par         font-size: 20px !important;\par         text-align: center !important;\par         line-height: 23px !important;\par         color: #323232 !important;\par       \}\par \par       .button-store \{\par         display: inline-block !important;\par         margin:0 8px !important;\par       \}\par \par       .button-store_apple \{\par         width: 138px !important;\par         height: 47px !important;\par       \}\par \par       .button-store_android \{\par         width: 136px !important;\par         height: 47px !important;\par       \}\par \par       .main \{\par         padding: 0 40px !important;\par       \}\par \par       .two-column \{\par         margin: 0 !important;\par       \}\par \par       .feature \{\par         display: block !important;\par         width: auto !important;\par         margin: 48px 10px 55px !important;\par         text-align: left !important;\par       \}\par \par       .feature .icon \{\par         width: 96px !important;\par         margin: 0 auto !important;\par         padding-right: 40px !important;\par       \}\par \par       .feature .title \{\par         margin: 23px 0 16px !important;\par         padding: 0 !important;\par         font-size: 24px !important;\par         color: #000000 !important;\par         line-height: 28px !important;\par       \}\par \par       .feature .description \{\par         margin-top: 26px !important;\par         text-align: left !important;\par         font-size: 20px !important;\par         color: #000000 !important;\par         line-height: 28px !important;\par       \}\par     \}\par \par \par     @media only screen and (max-width: 490px) \{\par \par       .header .name \{\par         float: none !important;\par         text-align: center !important;\par         font-size: 20px !important;\par         line-height: 28px !important;\par       \}\par \par       .header .name strong \{\par         font-size: 20px !important;\par         font-weight: normal !important;\par         color: #ffffff !important;\par         text-align: center !important;\par         line-height: 28px !important;\par       \}\par \par       .header .title \{\par         padding-bottom: 12px !important;\par         font-size: 28px !important;\par         color: #ffffff  !important;\par         text-align: center !important;\par         line-height: 36px !important;\par       \}\par \par       .header .title_full \{\par         display: block !important;\par       \}\par \par       .header .title_short \{\par         display: none !important;\par         overflow: hidden !important;\par         float: left !important;\par         line-height: 0px !important;\par       \}\par \par       .header .description \{\par         font-size: 20px !important;\par         color: #b3dfff !important;\par         line-height: 28px !important;\par       \}\par \par       .header .description_full \{\par         display: none !important;\par         overflow: hidden !important;\par         float: left;\par         line-height: 0px !important;\par       \}\par \par       .lead-image img \{\par         vertical-align: top !important;\par       \}\par \par       .store \{\par         padding: 24px 20px 33px !important;\par         text-align: center !important;\par         background-color: #ffde2a !important;\par       \}\par \par       .store .title \{\par         display: block !important;\par         width: auto !important;\par         padding-bottom: 24px !important;\par         font-size: 20px !important;\par         color: #323232 !important;\par         text-align: center !important;\par         line-height: 23px !important;\par       \}\par \par       .button-store \{\par         display: inline-block !important;\par       \}\par \par       .button-store_android \{\par         width: 136px !important;\par         height: 47px !important;\par       \}\par \par       .button-store_apple \{\par         width: 138px !important;\par         height: 47px !important;\par       \}\par \par       .main \{\par         padding: 0 20px !important;\par       \}\par \par       .feature \{\par         margin: 48px 10px 55px !important;\par         text-align: center !important;\par       \}\par \par       .feature .icon \{\par         display: block !important;\par       \}\par \par       .feature .title \{\par         display: block !important;\par         text-align: center !important;\par       \}\par \par       .feature .description \{\par         text-align: center !important;\par         padding: 0 !important;\par         font-size: 20px !important;\par         color: #000000 !important;\par         line-height: 28px !important;\par         word-wrap: break-word;\par       \}\par \par \par     \}\par \par \par   }
+{\*\htmltag249 </style>}
+{\*\htmltag1 \par }
+{\*\htmltag41 </head>}
+{\*\htmltag2 \par }
+{\*\htmltag50 <body style="margin: 0;padding: 0;font-family: arial, sans-serif;">}
+{\*\htmltag0 \par }
+{\*\htmltag240   }
+{\*\htmltag96 <div class="letter" style="max-width: 680px;margin: 0 auto;font-family: arial, sans-serif;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240     }
+{\*\htmltag96 <table style="max-width: 680px" align="center" cellspacing="0" cellpadding="0" border="0">}\htmlrtf {\pard\plain \f0\fs24 \htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240     }
+{\*\htmltag240 <!--[if mso ]>\par       <table align="center" cellspacing="0" cellpadding="0" border="0" width="680">\par     <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240       }
+{\*\htmltag96 <tbody>}
+{\*\htmltag0 \par }
+{\*\htmltag240         }
+{\*\htmltag64 <tr>}\htmlrtf {\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84         }
+{\*\htmltag148 <td style="vertical-align: top;font-family: arial, sans-serif;" align="center" valign="top">}\htmlrtf {\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84           }\htmlrtf }\htmlrtf0 \htmlrtf}\htmlrtf0
+
+{\*\htmltag96 <div class="header" style="padding: 19px;padding-bottom: 0;background-color: #168de2;text-align: center;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag240 <!--[if mso ]>\par               <div style="line-height: 24px">\par                 <br>\par               </div>\par             <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="logo" style="float: right;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img\par                         src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/44_-mail_b.png"\par                         alt="Mail.ru Logo" height="44" width="115">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/44_-mail_b.png"}}{\fldrslt\cf1\ul {\chbrdr\brdrsh Mail.ru Logo}}}\htmlrtf0 {\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="name" style="float: left;margin: 0;font-size: 20px;color: #b3dfff;line-height: 36px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag0 \par }
+{\*\htmltag240             }{\*\htmltag64}\htmlrtf {\htmlrtf0 \'c7\'e4\'f0\'e0\'e2\'f1\'f2\'e2\'f3\'e9\'f2\'e5 
+{\*\htmltag84 <strong style="font-size: 20px;font-weight: normal;color: #ffffff;text-align: center;line-height: 28px;">}\htmlrtf {\b \htmlrtf0 !
+{\*\htmltag92 </strong>}\htmlrtf }\htmlrtf0 
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84             }
+{\*\htmltag4 \par }
+{\*\htmltag84             }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag0 \par }
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="title title_full" style="font-family: arial, sans-serif;clear: both;margin: 0;padding: 38px 0 25px;font-size: 28px;color: #ffffff;text-align: center;background-color: #168de2;display: none;overflow: hidden;float: left;line-height: 0px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cf\'ee\'eb\'fc\'e7\'f3\'e9\'f2\'e5\'f1\'fc \'cf\'ee\'f7\'f2\'ee\'e9 \'f1 \'ec\'ee\'e1\'e8\'eb\'fc\'ed\'ee\'e3\'ee, \'ed\'e0\'f5\'ee\'e4\'ff\'f1\'fc \'e2 \'eb\'fe\'e1\'ee\'e9 \'f2\'ee\'f7\'ea\'e5 \'c7\'e5\'ec\'eb\'e8{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="title title_short" style="font-family: arial, sans-serif;clear: both;margin: 0;padding: 38px 0 25px;font-size: 28px;color: #ffffff;text-align: center;background-color: #168de2;display: block;overflow: visible;float: none;line-height: 100%;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cf\'ee\'eb\'fc\'e7\'f3\'e9\'f2\'e5\'f1\'fc \'cf\'ee\'f7\'f2\'ee\'e9 \'f1 \'ec\'ee\'e1\'e8\'eb\'fc\'ed\'ee\'e3\'ee{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="description description_full" style="font-family: arial, sans-serif;font-size: 20px;color: #b3dfff;line-height: 28px;display: block;overflow: visible;float: none;background-color: #168de2;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cf\'ee\'f7\'f2\'e0 \'e2\'f1\'e5\'e3\'e4\'e0 \'f0\'ff\'e4\'ee\'ec, \'e4\'e0\'e6\'e5 \'e5\'f1\'eb\'e8 \'e2\'fb \'e4\'e0\'eb\'e5\'ea\'ee \'ee\'f2 \'ea\'ee\'ec\'ef\'fc\'fe\'f2\'e5\'f0\'e0. \'d7\'e8\'f2\'e0\'e9\'f2\'e5 \'e8 \'ee\'f2\'ef\'f0\'e0\'e2\'eb\'ff\'e9\'f2\'e5 \'ef\'e8\'f1\'fc\'ec\'e0, \'ef\'f0\'e8\'ea\'f0\'e5\'ef\'eb\'ff\'e9\'f2\'e5 \'e8 \'ef\'f0\'ee\'f1\'ec\'e0\'f2\'f0\'e8\'e2\'e0\'e9\'f2\'e5 \'f4\'e0\'e9\'eb\'fb, \'ed\'e0\'f5\'ee\'e4\'ff\'f1\'fc \'e2 \'eb\'fe\'e1\'ee\'e9 \'f2\'ee\'f7\'ea\'e5 \'c7\'e5\'ec\'eb\'e8.{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag96 <div class="lead-image">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if !mso]><!-- -->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/head.png" width="100%" height="100%" alt="" style="vertical-align: top;">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/head.png"}}{\fldrslt\cf1\ul }}\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84               }
+{\*\htmltag244 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84               }
+{\*\htmltag244 <!--[if mso]>\par                 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/head.png" width="680" height="100%" alt="" />\par               <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84           }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag96 <div class="store" style="padding: 40px 20px;text-align: center;background-color: #ffde2a;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag240 <!--[if mso ]>\par               <table cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #ffde2a;">\par                 <tr>\par                   <td colspan="4" height="15">&nbsp;</td>\par                 </tr>\par                 <tr>\par                   <td width="20">&nbsp;</td>\par                   <td align="right">\par             <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="title" style="font-family: arial, sans-serif;width: 160px;font-size: 28px;line-height: 32px;margin-bottom: 0;display: inline-block;text-align: left;vertical-align: top;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'d3\'f1\'f2\'e0\'ed\'ee\'e2\'e8\'f2\'e5 \'ef\'f0\'e8\'eb\'ee\'e6\'e5\'ed\'e8\'e5{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag240 <!--[if mso ]>\par                   </td><td>\par             <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="button-store button-store_apple" style="display: inline-block;margin: 0 8px;width: 183px;height: 64px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTY5LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYxNzM1In0.kZI-79TlvTFEliI4ZRFEVoCeJhlIFpmk2eC47ekR1ZQ" data-url-index="43569">}\htmlrtf {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTY5LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYxNzM1In0.kZI-79TlvTFEliI4ZRFEVoCeJhlIFpmk2eC47ekR1ZQ"}}{\fldrslt\cf1\ul \htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                 }
+{\*\htmltag244 <!--[if !mso]><!-- -->}
+{\*\htmltag4 \par }
+{\*\htmltag84                  }
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/app_store.png" width="100%" height="100%" alt="App Store">}\htmlrtf {\chbrdr\brdrsh App Store}\htmlrtf0 
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84                 }
+{\*\htmltag244 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                 }
+{\*\htmltag244 <!--[if mso]>\par                   <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/app_store.png" width="183" height="64" alt="App Store" />\par                 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag4 \par }
+{\*\htmltag84               }\htmlrtf }\htmlrtf0 \htmlrtf }\htmlrtf0 
+{\*\htmltag92 </a>}
+{\*\htmltag4 \par }
+{\*\htmltag84             }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag240 <!--[if mso ]>\par                   </td><td>\par             <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="button-store button-store_android" style="display: inline-block;margin: 0 8px;width: 183px;height: 64px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTcwLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYxNzUzIn0.UfxD7z6j6Gdox33__EQpfU-K8KKtA7MifcmZ27LRZq0" data-url-index="43570">}\htmlrtf {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTcwLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYxNzUzIn0.UfxD7z6j6Gdox33__EQpfU-K8KKtA7MifcmZ27LRZq0"}}{\fldrslt\cf1\ul \htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                 }
+{\*\htmltag244 <!--[if !mso]><!-- -->}
+{\*\htmltag4 \par }
+{\*\htmltag84                  }
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/play_store.png" width="100%" height="100%" alt="Google Play">}\htmlrtf {\chbrdr\brdrsh Google Play}\htmlrtf0 
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84                 }
+{\*\htmltag244 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                 }
+{\*\htmltag244 <!--[if mso]>\par                   <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/play_store.png" width="183" height="64" alt="Google Play" />\par                 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag4 \par }
+{\*\htmltag84               }\htmlrtf }\htmlrtf0 \htmlrtf }\htmlrtf0 
+{\*\htmltag92 </a>}
+{\*\htmltag4 \par }
+{\*\htmltag84             }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag240 <!--[if mso ]>\par                   </td>\par                 </tr>\par                 <tr>\par                   <td colspan="4" height="15">&nbsp;</td>\par                 </tr>\par               </table>\par             <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag96 <div class="main" style="padding: 50px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="two-column" style="margin-bottom: 60px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="100%">\par                   <tr>\par                     <td width="50%">\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="90%">\par                     <tr>\par                       <td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                   }
+{\*\htmltag240 <!--[if !mso]><!-- -->}
+{\*\htmltag0 \par }
+{\*\htmltag240                     }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/006.png" width="100%" alt="">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/006.png"}}{\fldrslt\cf1\ul }}\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--[if mso]>\par                     <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/006.png" width="48"  alt="">\par                   <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                 }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td><td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cc\'e3\'ed\'ee\'e2\'e5\'ed\'ed\'fb\'e5 \'f3\'e2\'e5\'e4\'ee\'ec\'eb\'e5\'ed\'e8\'ff{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                     <tr>\par                       <td colspan="2">\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'d3\'e7\'ed\'e0\'e2\'e0\'e9\'f2\'e5 \'ee \'ed\'ee\'e2\'fb\'f5 \'ef\'e8\'f1\'fc\'ec\'e0\'f5 \'ec\'e3\'ed\'ee\'e2\'e5\'ed\'ed\'ee. \'cf\'f0\'ee\'e2\'e5\'f0\'ff\'f2\'fc \'ef\'ee\'f7\'f2\'f3 \'e2\'f0\'f3\'f7\'ed\'f3\'fe \'ed\'e5 \'ed\'f3\'e6\'ed\'ee.{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                   </table>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                   </td><td width="50%">\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="90%">\par                     <tr>\par                       <td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                   }
+{\*\htmltag240 <!--[if !mso]><!-- -->}
+{\*\htmltag0 \par }
+{\*\htmltag240                     }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/005.png" width="100%" alt="">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/005.png"}}{\fldrslt\cf1\ul }}\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--[if mso]>\par                     <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/005.png" width="48"  alt="">\par                   <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                 }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td><td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cf\'f0\'ee\'f1\'f2\'ee\'e9 \'e8 \'f3\'e4\'ee\'e1\'ed\'fb\'e9 \'e8\'ed\'f2\'e5\'f0\'f4\'e5\'e9\'f1{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                     <tr>\par                       <td colspan="2">\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'d7\'e8\'f2\'e0\'e9\'f2\'e5 \'ef\'ee\'f7\'f2\'f3, \'ef\'e8\'f8\'e8\'f2\'e5 \'ef\'e8\'f1\'fc\'ec\'e0, \'ed\'e0\'f5\'ee\'e4\'e8\'f2\'e5 \'f1\'e0\'ec\'ee\'e5 \'e2\'e0\'e6\'ed\'ee\'e5 \'e8 \'e1\'fb\'f1\'f2\'f0\'ee \'f0\'e5\'f8\'e0\'e9\'f2\'e5 \'f0\'e0\'e7\'ed\'fb\'e5 \'e7\'e0\'e4\'e0\'f7\'e8.{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                   </table>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                     </td>\par                   </tr>\par                 </table>\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="two-column" style="margin-bottom: 60px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="100%">\par                   <tr>\par                     <td width="50%">\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="90%">\par                     <tr>\par                       <td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                   }
+{\*\htmltag240 <!--[if !mso]><!-- -->}
+{\*\htmltag0 \par }
+{\*\htmltag240                     }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/002.png" width="100%" alt="">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/002.png"}}{\fldrslt\cf1\ul }}\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--[if mso]>\par                     <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/002.png" width="48"  alt="">\par                   <!}
+{\*\htmltag244 --<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                 }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td><td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'c1\'fb\'f1\'f2\'f0\'fb\'e9 \'ef\'ee\'e8\'f1\'ea{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                     <tr>\par                       <td colspan="2">\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cd\'e0\'f5\'ee\'e4\'e8\'f2\'e5 \'ef\'e8\'f1\'fc\'ec\'e0 \'e7\'e0 \'e2\'f1\'fe \'e8\'f1\'f2\'ee\'f0\'e8\'fe \'ef\'e5\'f0\'e5\'ef\'e8\'f1\'ea\'e8. \'cf\'ee\'eb\'fc\'e7\'f3\'e9\'f2\'e5\'f1\'fc \'ef\'ee\'e8\'f1\'ea\'ee\'e2\'fb\'ec\'e8 \'ef\'ee\'e4\'f1\'ea\'e0\'e7\'ea\'e0\'ec\'e8.{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                   </table>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                   </td><td width="50%">\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="90%">\par                     <tr>\par                       <td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                   }
+{\*\htmltag240 <!--[if !mso]><!-- -->}
+{\*\htmltag0 \par }
+{\*\htmltag240                     }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/004.png" width="100%" alt="">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/004.png"}}{\fldrslt\cf1\ul }}\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--[if mso]>\par                     <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/004.png" width="48"  alt="">\par                   <!}
+{\*\htmltag244 --<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                 }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td><td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cc\'f3\'eb\'fc\'f2\'e8\'e0\'ea\'ea\'e0\'f3\'ed\'f2{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                     <tr>\par                       <td colspan="2">\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'d1\'ee\'e1\'e5\'f0\'e8\'f2\'e5 \'e2\'f1\'e5 \'ef\'ee\'f7\'f2\'ee\'e2\'fb\'e5 \'ff\'f9\'e8\'ea\'e8 \'e2 \'fd\'f2\'ee\'ec \'ef\'f0\'e8\'eb\'ee\'e6\'e5\'ed\'e8\'e8. \'cf\'ee\'eb\'fc\'e7\'f3\'e9\'f2\'e5\'f1\'fc \'e8\'ec\'e8 \'ee\'e4\'ed\'ee\'e2\'f0\'e5\'ec\'e5\'ed\'ed\'ee, \'ef\'e5\'f0\'e5\'ea\'eb\'fe\'f7\'e0\'ff\'f1\'fc \'e2 \'ee\'e4\'e8\'ed \'ea\'eb\'e8\'ea.{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                   </table>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                     </td>\par                   </tr>\par                 </table>\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="two-column" style="margin-bottom: 60px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="100%">\par                   <tr>\par                     <td width="50%">\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="90%">\par                     <tr>\par                       <td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                   }
+{\*\htmltag240 <!--[if !mso]><!-- -->}
+{\*\htmltag0 \par }
+{\*\htmltag240                     }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/003.png" width="100%" alt="">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/003.png"}}{\fldrslt\cf1\ul }}\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--[if mso]>\par                     <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/003.png" width="48"  alt="">\par                   <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                 }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td><td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cd\'e0\'f1\'f2\'f0\'ee\'e9\'ea\'e8 \'f3\'e2\'e5\'e4\'ee\'ec\'eb\'e5\'ed\'e8\'e9 \'ee \'ef\'e8\'f1\'fc\'ec\'e0\'f5{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                     <tr>\par                       <td colspan="2">\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cd\'e0\'f1\'f2\'f0\'ee\'e9\'f2\'e5 \'f3\'e2\'e5\'e4\'ee\'ec\'eb\'e5\'ed\'e8\'ff \'ee \'ed\'ee\'e2\'fb\'f5 \'ef\'e8\'f1\'fc\'ec\'e0\'f5. \'c1\'eb\'e0\'e3\'ee\'e4\'e0\'f0\'ff \'e3\'e8\'e1\'ea\'ee\'e9 \'f1\'e8\'f1\'f2\'e5\'ec\'e5 \'ed\'e0\'f1\'f2\'f0\'ee\'e5\'ea \'ec\'ee\'e6\'ed\'ee \'ef\'ee\'eb\'f3\'f7\'e0\'f2\'fc \'f3\'e2\'e5\'e4\'ee\'ec\'eb\'e5\'ed\'e8\'ff \'ee \'ef\'e8\'f1\'fc\'ec\'e0\'f5 \'e8\'e7 \'ee\'ef\'f0\'e5\'e4\'e5\'eb\'e5\'ed\'ed\'ee\'e9 \'ef\'e0\'ef\'ea\'e8 \'e8\'eb\'e8 \'e2 \'ee\'ef\'f0\'e5\'e4\'e5\'eb\'e5\'ed\'ed\'ee\'e5 \'e2\'f0\'e5\'ec\'ff.{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                   </table>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                   </td><td width="50%">\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="90%">\par                     <tr>\par                       <td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                   }
+{\*\htmltag240 <!--[if !mso]><!-- -->}
+{\*\htmltag0 \par }
+{\*\htmltag240                     }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/001.png" width="100%" alt="">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/001.png"}}{\fldrslt\cf1\ul }}\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                   }
+{\*\htmltag244 <!--[if mso]>\par                     <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/001.png" width="48"  alt="">\par                   <!--<![endif]-->}
+{\*\htmltag4 \par }
+{\*\htmltag84                 }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td><td>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'d7\'f2\'e5\'ed\'e8\'e5 \'ef\'e8\'f1\'e5\'ec \'e1\'e5\'e7 \'ef\'ee\'e4\'ea\'eb\'fe\'f7\'e5\'ed\'e8\'ff \'ea \'e8\'ed\'f2\'e5\'f0\'ed\'e5\'f2\'f3{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                     <tr>\par                       <td colspan="2">\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag96 <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'cf\'f0\'ee\'f1\'ec\'e0\'f2\'f0\'e8\'e2\'e0\'e9\'f2\'e5 \'ef\'e8\'f1\'fc\'ec\'e0 \'e1\'e5\'e7 \'ef\'ee\'e4\'ea\'eb\'fe\'f7\'e5\'ed\'e8\'ff \'ea \'e8\'ed\'f2\'e5\'f0\'ed\'e5\'f2\'f3, \'ed\'e0\'ef\'f0\'e8\'ec\'e5\'f0, \'ed\'e0\'f5\'ee\'e4\'ff\'f1\'fc \'ed\'e0 \'e1\'ee\'f0\'f2\'f3 \'f1\'e0\'ec\'ee\'eb\'b8\'f2\'e0 \'e8\'eb\'e8 \'f2\'e0\'ec, \'e3\'e4\'e5 \'ef\'eb\'ee\'f5\'ee \'f0\'e0\'e1\'ee\'f2\'e0\'e5\'f2 \'f1\'ee\'f2\'ee\'e2\'e0\'ff \'f1\'e2\'ff\'e7\'fc.{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240                 }
+{\*\htmltag240 <!--[if mso ]>\par                       </td>\par                     </tr>\par                   </table>\par                 <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                     </td>\par                   </tr>\par                 </table>\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag96 <div class="main-feature" style="padding: 48px 19px 60px;background: #f0f0f0;text-align: center;background-image: url(https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/pattern.png);background-position: 50% 50%;background-size: contain;background-repeat: no-repeat;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="title" style="font-family: arial, sans-serif;padding: 0 0 28px;font-size: 28px;color: #000000;text-align: center;line-height: 36px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'d1\'e8\'ed\'f5\'f0\'ee\'ed\'e8\'e7\'e0\'f6\'e8\'ff \'ef\'ee\'f7\'f2\'fb \'ed\'e0 \'e2\'f1\'e5\'f5 \'f3\'f1\'f2\'f0\'ee\'e9\'f1\'f2\'e2\'e0\'f5{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="image" style="padding: 0 20px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if !mso]><!-- -->}
+{\*\htmltag0 \par }
+{\*\htmltag240                 }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/bitmap.png" width="100%" height="100%" alt="">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/bitmap.png"}}{\fldrslt\cf1\ul }}\htmlrtf0 {\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--<![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso]>\par                 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/bitmap.png" width="680" height="100%" alt=""></div>\par               <!--<![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="description" style="font-family: arial, sans-serif;padding: 44px 0 0;font-size: 20px;color: #000000;text-align: center;line-height: 28px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 \'c2 \'ef\'f0\'e8\'eb\'ee\'e6\'e5\'ed\'e8\'e8 \'e5\'f1\'f2\'fc \'e2\'f1\'b8 \'ed\'e5\'ee\'e1\'f5\'ee\'e4\'e8\'ec\'ee\'e5 \'e4\'eb\'ff \'f0\'e0\'e1\'ee\'f2\'fb \'f1 \'ef\'ee\'f7\'f2\'ee\'e9: \'f1\'ef\'e8\'f1\'ee\'ea \'ef\'e8\'f1\'e5\'ec \'f1 \'e0\'e2\'e0\'f2\'e0\'f0\'ea\'e0\'ec\'e8, \'e2\'ee\'e7\'ec\'ee\'e6\'ed\'ee\'f1\'f2\'fc \'ee\'f2\'ef\'f0\'e0\'e2\'eb\'ff\'f2\'fc \'e8 \'ef\'ee\'eb\'f3\'f7\'e0\'f2\'fc \'e2\'eb\'ee\'e6\'e5\'ed\'e8\'ff, \'ef\'e5\'f0\'f1\'ee\'ed\'e0\'eb\'fc\'ed\'fb\'e9 \'f1\'ef\'e0\'ec-\'f4\'e8\'eb\'fc\'f2\'f0, \'f6\'e5\'ef\'ee\'f7\'ea\'e8 \'ef\'e8\'f1\'e5\'ec \'e8 \'ec\'ed\'ee\'e3\'ee\'e5 \'e4\'f0\'f3\'e3\'ee\'e5.{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag96 <div class="footer" style="margin: 48px 19px 60px;text-align: center;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="title" style="font-family: arial, sans-serif;margin-bottom: 24px;font-size: 20px;color: #323232;line-height: 23px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }{\*\htmltag64}\htmlrtf {\htmlrtf0 \'d1\'eb\'e5\'e4\'e8\'f2\'e5 \'e7\'e0 \'ed\'e0\'f8\'e8\'ec\'e8 \'ed\'ee\'e2\'ee\'f1\'f2\'ff\'ec\'e8
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84               }{}
+{\*\htmltag84 <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTcxLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTUzIn0.vHYFhCdC6FMc4m188LIB7ogyQjHF-e11ShV6WvfQSgk" class="link" style="color: #005bd1;text-decoration: none;" data-url-index="43571">}\htmlrtf {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTcxLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTUzIn0.vHYFhCdC6FMc4m188LIB7ogyQjHF-e11ShV6WvfQSgk"}}{\fldrslt\cf1\ul \htmlrtf0 \'e2 \'e1\'eb\'ee\'e3\'e5\htmlrtf }\htmlrtf0 \htmlrtf }\htmlrtf0 
+{\*\htmltag92 </a>}
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84               }\'cf\'ee\'f7\'f2\'fb \'e8 \'f1\'ee\'f6\'e8\'e0\'eb\'fc\'ed\'fb\'f5 \'f1\'e5\'f2\'ff\'f5:
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84             }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="social-links" style="margin-bottom: 34px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                 <table cellspacing="0" cellpadding="0" border="0" width="100%">\par                   <tr>\par                     <td>\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="social-link social-link_vk" style="display: inline;margin: 10px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTcyLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTE5In0.NyXnXmPqvfYt6dwlaTG83kM5aNywpttkSHMe0iXYcdA" data-url-index="43572">}\htmlrtf {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTcyLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTE5In0.NyXnXmPqvfYt6dwlaTG83kM5aNywpttkSHMe0iXYcdA"}}{\fldrslt\cf1\ul \htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_vk.png" width="64" height="64">}\htmlrtf }\htmlrtf0 \htmlrtf }\htmlrtf0 
+{\*\htmltag92 </a>}{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                     </td><td>\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="social-link social-link_vk" style="display: inline;margin: 10px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTczLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTExIn0.1Cp_IPfvy9wmwoLjHm1PyL-skQ95WPThiugjmlVHZv8" data-url-index="43573">}\htmlrtf {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTczLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTExIn0.1Cp_IPfvy9wmwoLjHm1PyL-skQ95WPThiugjmlVHZv8"}}{\fldrslt\cf1\ul \htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_ok.png" width="64" height="64">}\htmlrtf }\htmlrtf0 \htmlrtf }\htmlrtf0 
+{\*\htmltag92 </a>}{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                     </td><td>\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="social-link social-link_vk" style="display: inline;margin: 10px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc0LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyNzY0In0.EZ-vMKQ7imp6cro3s0xRrHIG1MCB8nfH47mPgVrAX4w" data-url-index="43574">}\htmlrtf {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc0LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyNzY0In0.EZ-vMKQ7imp6cro3s0xRrHIG1MCB8nfH47mPgVrAX4w"}}{\fldrslt\cf1\ul \htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_facebook.png" width="64" height="64">}\htmlrtf }\htmlrtf0 \htmlrtf }\htmlrtf0 
+{\*\htmltag92 </a>}{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                     </td><td>\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="social-link social-link_vk" style="display: inline;margin: 10px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc1LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTU1In0.iDoqOSwgNKgJP7bWXJ52ogG33trO48EJ_NhSSywrYDQ" data-url-index="43575">}\htmlrtf {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc1LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTU1In0.iDoqOSwgNKgJP7bWXJ52ogG33trO48EJ_NhSSywrYDQ"}}{\fldrslt\cf1\ul \htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_twitter.png" width="64" height="64">}\htmlrtf }\htmlrtf0 \htmlrtf }\htmlrtf0 
+{\*\htmltag92 </a>}{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                     </td><td>\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag96 <div class="social-link social-link_vk" style="display: inline;margin: 10px;">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc2LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTQ4In0.Bt67abHLZp_rhmUGETKt-GPxu419RBvR4sflHDT0rCY" data-url-index="43576">}\htmlrtf {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc2LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTQ4In0.Bt67abHLZp_rhmUGETKt-GPxu419RBvR4sflHDT0rCY"}}{\fldrslt\cf1\ul \htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_moymir.png" width="64" height="64">}\htmlrtf }\htmlrtf0 \htmlrtf }\htmlrtf0 
+{\*\htmltag92 </a>}{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag240 <!--[if mso ]>\par                     </td>\par                   </tr>\par                 </table>\par               <![endif]-->}
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="separator" style="margin: 0 74px;line-height: 1px;border-bottom: 1px solid #999;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="description" style="font-family: arial, sans-serif;font-size: 20px;color: #999999;line-height: 28px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag64 <p>}\htmlrtf \par
+\htmlrtf0 \htmlrtf {\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                 }\'c5\'f1\'eb\'e8 \'f3 \'e2\'e0\'f1 \'e2\'ee\'e7\'ed\'e8\'ea\'ed\'f3\'f2
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84                 }\'ea\'e0\'ea\'e8\'e5-\'ed\'e8\'e1\'f3\'e4\'fc \'ef\'f0\'ee\'e1\'eb\'e5\'ec\'fb
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84                 }\'f1 \'ed\'e0\'f1\'f2\'f0\'ee\'e9\'ea\'ee\'e9 \'ef\'ee\'f7\'f2\'fb, \'e2\'fb
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84                 }\'ec\'ee\'e6\'e5\'f2 \'e2\'ee\'f1\'ef\'ee\'eb\'fc\'e7\'ee\'e2\'e0\'f2\'fc\'f1\'ff
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84                 }\'ed\'e0\'f8\'e5\'e9 \'ee\'ed\'eb\'e0\'e9\'ed {}
+{\*\htmltag84 <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc3LCJ1cmwiOiJodHRwczovL2hlbHAubWFpbC5ydS9tYWlsLWhlbHAvIn0.AdeI6Dt9VTNgoxm_kJwHaognuYnOi-yZPHAaZtzbOE4" class="link" style="color: #005bd1;text-decoration: none;" data-url-index="43577">}\htmlrtf {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc3LCJ1cmwiOiJodHRwczovL2hlbHAubWFpbC5ydS9tYWlsLWhlbHAvIn0.AdeI6Dt9VTNgoxm_kJwHaognuYnOi-yZPHAaZtzbOE4"}}{\fldrslt\cf1\ul \htmlrtf0 \'ef\'ee\'ec\'ee\'f9\'fc\'fe\htmlrtf }\htmlrtf0 \htmlrtf }\htmlrtf0 
+{\*\htmltag92 </a>}
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84               }\htmlrtf\par}\htmlrtf0
+\htmlrtf \par
+\htmlrtf0 
+{\*\htmltag72 </p>}
+{\*\htmltag0 \par }
+{\*\htmltag240               }
+{\*\htmltag64 <p>}\htmlrtf {\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84                 }\'d1 \'ed\'e0\'e8\'eb\'f3\'f7\'f8\'e8\'ec\'e8 \'ef\'ee\'e6\'e5\'eb\'e0\'ed\'e8\'ff\'ec\'e8, \'ea\'ee\'ec\'e0\'ed\'e4\'e0 \'cf\'ee\'f7\'f2\'fb Mail.ru
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84               }\htmlrtf\par}\htmlrtf0
+\htmlrtf \par
+\htmlrtf0 
+{\*\htmltag72 </p>}
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="copy" style="font-size: 13px;color: #999999;line-height: 24px;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }{\*\htmltag64}\htmlrtf {\htmlrtf0 Mail.ru Group, \'cc\'ee\'f1\'ea\'e2\'e0 -
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84               }\'c2\'f1\'e5
+{\*\htmltag84 &nbsp;}\htmlrtf \'a0\htmlrtf0 \'ef\'f0\'e0\'e2\'e0 \'e7\'e0\'f9\'e8\'f9\'e5\'ed\'fb.
+{\*\htmltag4 \par }\htmlrtf  \htmlrtf0 
+{\*\htmltag84             }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240             }
+{\*\htmltag96 <div class="logo" style="margin: 24px 0;">}\htmlrtf {\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240               }{\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img\par                 src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/32_-mail_g.png"\par                 style="width:95px;height:32px;" alt="@Mail.ru"\par                 height="32" width="95">}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/32_-mail_g.png"}}{\fldrslt\cf1\ul {\chbrdr\brdrsh @Mail.ru}}}\htmlrtf0 
+{\*\htmltag4 \par }
+{\*\htmltag84             }{\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240           }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240         }
+{\*\htmltag248 </td>}
+{\*\htmltag0 \par }
+{\*\htmltag240         }
+{\*\htmltag72 </tr>}
+{\*\htmltag0 \par }
+{\*\htmltag240       }
+{\*\htmltag104 </tbody>}
+{\*\htmltag0 \par }
+{\*\htmltag240     }
+{\*\htmltag104 </table>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag240   }
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag0 \par }
+{\*\htmltag96 <div style="background-color: #fff">}\htmlrtf {\htmlrtf0 {\*\htmltag64}\htmlrtf {\htmlrtf0 
+{\*\htmltag84 <img src="https://mailer.mail.ru/pub/mailer/pixel/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUifQ.kBxrr6UFII4HGPuEInkOKX_MpZKSCLhZk6lGnVCJyC8" width="0" height="0" alt="."/>}\htmlrtf  {\field{\*\fldinst{HYPERLINK "https://mailer.mail.ru/pub/mailer/pixel/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUifQ.kBxrr6UFII4HGPuEInkOKX_MpZKSCLhZk6lGnVCJyC8"}}{\fldrslt\cf1\ul {\chbrdr\brdrsh .}}}\htmlrtf0 {\*\htmltag72}\htmlrtf\par}\htmlrtf0
+
+{\*\htmltag104 </div>}\htmlrtf }\htmlrtf0 
+{\*\htmltag58 </body>}
+{\*\htmltag2 \par }
+{\*\htmltag27 </html>}}Jf

--- a/src/test/resources/test-messages/rtf-to-html-output.html
+++ b/src/test/resources/test-messages/rtf-to-html-output.html
@@ -1,0 +1,874 @@
+<!DOCTYPE html>
+<html lang="en" style="margin: 0;padding: 0;font-family: arial, sans-serif;">
+<head>
+  
+  <style type="text/css">
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: arial, sans-serif;
+    }
+    .letter {
+      max-width: 680px;
+      margin: 0 auto;
+      font-family: arial, sans-serif;
+    }
+
+    td,
+    .title,
+    .description {
+      font-family: arial, sans-serif;
+    }
+
+
+
+    .header {
+      padding: 19px;
+      padding-bottom: 0;
+      background-color: #168de2;
+      text-align: center;
+    }
+
+    .header .logo {
+      float:right;
+    }
+
+    .header .name {
+      float: left;
+      margin: 0;
+      font-size: 20px;
+      color: #b3dfff;
+      line-height: 36px;
+    }
+
+    .header .name strong {
+      font-size: 20px;
+      font-weight: normal;
+      color: #ffffff;
+      text-align: center;
+      line-height: 28px;
+    }
+
+    .header .title {
+      clear: both;
+      margin: 0;
+      padding: 38px 0 25px;
+      font-size: 28px;
+      color: #ffffff;
+      text-align: center;
+      background-color: #168de2;
+    }
+
+    .header .title_full {
+      display: none;
+      overflow:hidden;
+      float:left;
+      line-height:0px;
+    }
+
+    .header .title_short {
+      display: block;
+      overflow: visible;
+      float: none;
+      line-height:100%;
+    }
+
+    .header .description {
+      font-size: 20px;
+      color: #b3dfff;
+      line-height: 28px;
+    }
+
+    .header .description_full {
+      display: block;
+      overflow: visible;
+      float: none;
+      line-height:28px;
+      background-color: #168de2;
+    }
+
+    .lead-image img {
+      vertical-align: top;
+    }
+
+    .store {
+      padding: 40px 20px;
+      text-align: center;
+        background-color: #ffde2a;
+    }
+    .store .title {
+      width: 160px;
+      font-size: 28px;
+      line-height: 32px;
+      margin-bottom: 0;
+      display: inline-block;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .button-store {
+      display: inline-block;
+      margin:0 8px;
+    }
+
+    .button-store_android {
+      width: 183px;
+      height: 64px;
+    }
+
+    .button-store_apple {
+      width: 183px;
+      height: 64px;
+    }
+
+    .main {
+      padding: 50px;
+    }
+
+    .two-column {
+      margin-bottom: 60px;
+    }
+    .feature {
+      width: 50%;
+      margin: 30px;
+      display: table-cell;
+    }
+
+
+    .feature .icon,
+    .feature .title {
+      display: table-cell;
+      vertical-align: middle;
+      text-align: left;
+    }
+
+    .feature .title {
+      padding-right: 20px;
+      font-size: 20px;
+      font-weight: bold;
+      line-height: 28px;
+    }
+
+    .feature .icon {
+      width: 48px;
+      padding-right: 20px;
+      padding-left: 20px;
+    }
+
+    .feature .description {
+      margin-top: 18px;
+      padding-left: 20px;
+      padding-right: 20px;
+      text-align: left;
+      font-size: 17px;
+      line-height: 24px;
+    }
+
+    .main-feature {
+      padding: 48px 19px 60px;
+      background: #f0f0f0;
+      text-align: center;
+      background-image: url(https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/pattern.png);
+      background-position: 50% 50%;
+      background-size: contain;
+      background-repeat: no-repeat;
+    }
+
+    .main-feature .title {
+      padding: 0 0 28px;
+      font-size: 28px;
+      color: #000000;
+      text-align: center;
+
+      line-height: 36px;
+    }
+
+    .main-feature .description {
+      padding: 44px 0 0;
+      font-size: 20px;
+      color: #000000;
+      text-align: center;
+      line-height: 28px;
+    }
+
+    .main-feature .image {
+      padding: 0 20px;
+    }
+
+    .footer {
+      margin: 48px 19px 60px;
+      text-align: center;
+    }
+
+    .footer .title {
+      margin-bottom: 24px;
+      font-size: 20px;
+      color: #323232;
+      line-height: 23px;
+    }
+
+    .footer .description {
+      font-size: 20px;
+      color: #999999;
+      line-height: 28px;
+    }
+
+    .footer .service-links,
+    .footer .copy {
+      font-size: 13px;
+      color: #999999;
+      line-height: 24px;
+    }
+
+    .footer .social-links {
+      margin-bottom: 34px;
+    }
+
+    .footer .social-link {
+      display: inline;
+      margin: 10px;
+    }
+
+    .footer .separator {
+      margin: 0 74px;
+      line-height: 1px;
+      border-bottom: 1px solid #999;
+    }
+
+    .footer .logo {
+      margin: 24px 0;
+    }
+
+    .link {
+      color: #005bd1;
+      text-decoration: none;
+    }
+
+    .link:hover {
+      text-decoration: underline;
+    }
+
+
+    @media only screen and (max-width: 680px)  {
+
+      .header {
+        text-align: center !important;
+      }
+      .header .logo {
+        float: none !important;
+      }
+
+      .header .name {
+        float: none !important;
+        padding: 23px 0 21px !important;
+        text-align: center !important;
+        line-height: 28px !important;
+      }
+      .header .title {
+        padding: 0 0 12px !important;
+      }
+      .header .title_full {
+        display: block !important;
+        overflow: visible !important;
+        float: none !important;
+        line-height: 36px !important;
+      }
+
+      .header .title_short {
+        display: none !important;
+        overflow: hidden !important;
+        float: left !important;
+        line-height: 0px !important;
+      }
+
+      .description_full {
+        display: none !important;
+        overflow: hidden !important;
+        float: left !important;
+        line-height: 0px !important;
+      }
+
+      .store .title {
+        width: 115px  !important;
+        margin-bottom: 0 !important;
+        display: inline-block !important;
+        vertical-align: top !important;
+        font-size: 20px !important;
+        text-align: center !important;
+        line-height: 23px !important;
+        color: #323232 !important;
+      }
+
+      .button-store {
+        display: inline-block !important;
+        margin:0 8px !important;
+      }
+
+      .button-store_apple {
+        width: 138px !important;
+        height: 47px !important;
+      }
+
+      .button-store_android {
+        width: 136px !important;
+        height: 47px !important;
+      }
+
+      .main {
+        padding: 0 40px !important;
+      }
+
+      .two-column {
+        margin: 0 !important;
+      }
+
+      .feature {
+        display: block !important;
+        width: auto !important;
+        margin: 48px 10px 55px !important;
+        text-align: left !important;
+      }
+
+      .feature .icon {
+        width: 96px !important;
+        margin: 0 auto !important;
+        padding-right: 40px !important;
+      }
+
+      .feature .title {
+        margin: 23px 0 16px !important;
+        padding: 0 !important;
+        font-size: 24px !important;
+        color: #000000 !important;
+        line-height: 28px !important;
+      }
+
+      .feature .description {
+        margin-top: 26px !important;
+        text-align: left !important;
+        font-size: 20px !important;
+        color: #000000 !important;
+        line-height: 28px !important;
+      }
+    }
+
+
+    @media only screen and (max-width: 490px) {
+
+      .header .name {
+        float: none !important;
+        text-align: center !important;
+        font-size: 20px !important;
+        line-height: 28px !important;
+      }
+
+      .header .name strong {
+        font-size: 20px !important;
+        font-weight: normal !important;
+        color: #ffffff !important;
+        text-align: center !important;
+        line-height: 28px !important;
+      }
+
+      .header .title {
+        padding-bottom: 12px !important;
+        font-size: 28px !important;
+        color: #ffffff  !important;
+        text-align: center !important;
+        line-height: 36px !important;
+      }
+
+      .header .title_full {
+        display: block !important;
+      }
+
+      .header .title_short {
+        display: none !important;
+        overflow: hidden !important;
+        float: left !important;
+        line-height: 0px !important;
+      }
+
+      .header .description {
+        font-size: 20px !important;
+        color: #b3dfff !important;
+        line-height: 28px !important;
+      }
+
+      .header .description_full {
+        display: none !important;
+        overflow: hidden !important;
+        float: left;
+        line-height: 0px !important;
+      }
+
+      .lead-image img {
+        vertical-align: top !important;
+      }
+
+      .store {
+        padding: 24px 20px 33px !important;
+        text-align: center !important;
+        background-color: #ffde2a !important;
+      }
+
+      .store .title {
+        display: block !important;
+        width: auto !important;
+        padding-bottom: 24px !important;
+        font-size: 20px !important;
+        color: #323232 !important;
+        text-align: center !important;
+        line-height: 23px !important;
+      }
+
+      .button-store {
+        display: inline-block !important;
+      }
+
+      .button-store_android {
+        width: 136px !important;
+        height: 47px !important;
+      }
+
+      .button-store_apple {
+        width: 138px !important;
+        height: 47px !important;
+      }
+
+      .main {
+        padding: 0 20px !important;
+      }
+
+      .feature {
+        margin: 48px 10px 55px !important;
+        text-align: center !important;
+      }
+
+      .feature .icon {
+        display: block !important;
+      }
+
+      .feature .title {
+        display: block !important;
+        text-align: center !important;
+      }
+
+      .feature .description {
+        text-align: center !important;
+        padding: 0 !important;
+        font-size: 20px !important;
+        color: #000000 !important;
+        line-height: 28px !important;
+        word-wrap: break-word;
+      }
+
+
+    }
+
+
+  </style>
+</head>
+<body style="margin: 0;padding: 0;font-family: arial, sans-serif;">
+  <div class="letter" style="max-width: 680px;margin: 0 auto;font-family: arial, sans-serif;">
+    <table style="max-width: 680px" align="center" cellspacing="0" cellpadding="0" border="0">
+    <!--[if mso ]>
+      <table align="center" cellspacing="0" cellpadding="0" border="0" width="680">
+    <![endif]-->
+      <tbody>
+        <tr>
+        <td style="vertical-align: top;font-family: arial, sans-serif;" align="center" valign="top">
+          <div class="header" style="padding: 19px;padding-bottom: 0;background-color: #168de2;text-align: center;">
+            <!--[if mso ]>
+              <div style="line-height: 24px">
+                <br>
+              </div>
+            <![endif]-->
+            <div class="logo" style="float: right;"><img
+                        src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/44_-mail_b.png"
+                        alt="Mail.ru Logo" height="44" width="115"></div>
+
+            <div class="name" style="float: left;margin: 0;font-size: 20px;color: #b3dfff;line-height: 36px;">
+            
+            Здравствуйте <strong style="font-size: 20px;font-weight: normal;color: #ffffff;text-align: center;line-height: 28px;">!</strong>
+            
+            </div>
+
+
+            <div class="title title_full" style="font-family: arial, sans-serif;clear: both;margin: 0;padding: 38px 0 25px;font-size: 28px;color: #ffffff;text-align: center;background-color: #168de2;display: none;overflow: hidden;float: left;line-height: 0px;">Пользуйтесь Почтой с мобильного, находясь в любой точке Земли</div>
+            <div class="title title_short" style="font-family: arial, sans-serif;clear: both;margin: 0;padding: 38px 0 25px;font-size: 28px;color: #ffffff;text-align: center;background-color: #168de2;display: block;overflow: visible;float: none;line-height: 100%;">Пользуйтесь Почтой с мобильного</div>
+            <div class="description description_full" style="font-family: arial, sans-serif;font-size: 20px;color: #b3dfff;line-height: 28px;display: block;overflow: visible;float: none;background-color: #168de2;">Почта всегда рядом, даже если вы далеко от компьютера. Читайте и отправляйте письма, прикрепляйте и просматривайте файлы, находясь в любой точке Земли.</div>
+
+          </div>
+
+          <div class="lead-image">
+              <!--[if !mso]><!-- -->
+                <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/head.png" width="100%" height="100%" alt="" style="vertical-align: top;">
+              <!--<![endif]-->
+              <!--[if mso]>
+                <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/head.png" width="680" height="100%" alt="" />
+              <!--<![endif]-->
+          </div>
+
+          <div class="store" style="padding: 40px 20px;text-align: center;background-color: #ffde2a;">
+            <!--[if mso ]>
+              <table cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #ffde2a;">
+                <tr>
+                  <td colspan="4" height="15">&nbsp;</td>
+                </tr>
+                <tr>
+                  <td width="20">&nbsp;</td>
+                  <td align="right">
+            <![endif]-->
+            <div class="title" style="font-family: arial, sans-serif;width: 160px;font-size: 28px;line-height: 32px;margin-bottom: 0;display: inline-block;text-align: left;vertical-align: top;">Установите приложение</div>
+            <!--[if mso ]>
+                  </td><td>
+            <![endif]-->
+            <div class="button-store button-store_apple" style="display: inline-block;margin: 0 8px;width: 183px;height: 64px;">
+              <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTY5LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYxNzM1In0.kZI-79TlvTFEliI4ZRFEVoCeJhlIFpmk2eC47ekR1ZQ" data-url-index="43569">
+                <!--[if !mso]><!-- -->
+                 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/app_store.png" width="100%" height="100%" alt="App Store">
+                <!--<![endif]-->
+                <!--[if mso]>
+                  <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/app_store.png" width="183" height="64" alt="App Store" />
+                <!--<![endif]-->
+
+              </a>
+            </div>
+            <!--[if mso ]>
+                  </td><td>
+            <![endif]-->
+            <div class="button-store button-store_android" style="display: inline-block;margin: 0 8px;width: 183px;height: 64px;">
+              <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTcwLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYxNzUzIn0.UfxD7z6j6Gdox33__EQpfU-K8KKtA7MifcmZ27LRZq0" data-url-index="43570">
+                <!--[if !mso]><!-- -->
+                 <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/play_store.png" width="100%" height="100%" alt="Google Play">
+                <!--<![endif]-->
+                <!--[if mso]>
+                  <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/play_store.png" width="183" height="64" alt="Google Play" />
+                <!--<![endif]-->
+
+              </a>
+            </div>
+            <!--[if mso ]>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="4" height="15">&nbsp;</td>
+                </tr>
+              </table>
+            <![endif]-->
+          </div>
+          <div class="main" style="padding: 50px;">
+            <div class="two-column" style="margin-bottom: 60px;">
+              <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                  <tr>
+                    <td width="50%">
+              <![endif]-->
+              <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">
+                <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="90%">
+                    <tr>
+                      <td>
+                <![endif]-->
+                <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">
+                  <!--[if !mso]><!-- -->
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/006.png" width="100%" alt="">
+                  <!--<![endif]-->
+                  <!--[if mso]>
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/006.png" width="48"  alt="">
+                  <!--<![endif]-->
+                </div>
+                <!--[if mso ]>
+                      </td><td>
+                <![endif]-->
+                <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">Мгновенные уведомления</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td colspan="2">
+                <![endif]-->
+                <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">Узнавайте о новых письмах мгновенно. Проверять почту вручную не нужно.</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                  </table>
+                <![endif]-->
+              </div>
+              <!--[if mso ]>
+                  </td><td width="50%">
+              <![endif]-->
+              <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">
+                <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="90%">
+                    <tr>
+                      <td>
+                <![endif]-->
+                <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">
+                  <!--[if !mso]><!-- -->
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/005.png" width="100%" alt="">
+                  <!--<![endif]-->
+                  <!--[if mso]>
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/005.png" width="48"  alt="">
+                  <!--<![endif]-->
+                </div>
+                <!--[if mso ]>
+                      </td><td>
+                <![endif]-->
+                <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">Простой и удобный интерфейс</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td colspan="2">
+                <![endif]-->
+                <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">Читайте почту, пишите письма, находите самое важное и быстро решайте разные задачи.</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                  </table>
+                <![endif]-->
+              </div>
+              <!--[if mso ]>
+                    </td>
+                  </tr>
+                </table>
+              <![endif]-->
+            </div>
+            <div class="two-column" style="margin-bottom: 60px;">
+              <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                  <tr>
+                    <td width="50%">
+              <![endif]-->
+              <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">
+                <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="90%">
+                    <tr>
+                      <td>
+                <![endif]-->
+                <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">
+                  <!--[if !mso]><!-- -->
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/002.png" width="100%" alt="">
+                  <!--<![endif]-->
+                  <!--[if mso]>
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/002.png" width="48"  alt="">
+                  <!--<![endif]-->
+                </div>
+                <!--[if mso ]>
+                      </td><td>
+                <![endif]-->
+                <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">Быстрый поиск</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td colspan="2">
+                <![endif]-->
+                <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">Находите письма за всю историю переписки. Пользуйтесь поисковыми подсказками.</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                  </table>
+                <![endif]-->
+              </div>
+              <!--[if mso ]>
+                  </td><td width="50%">
+              <![endif]-->
+              <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">
+                <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="90%">
+                    <tr>
+                      <td>
+                <![endif]-->
+                <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">
+                  <!--[if !mso]><!-- -->
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/004.png" width="100%" alt="">
+                  <!--<![endif]-->
+                  <!--[if mso]>
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/004.png" width="48"  alt="">
+                  <!--<![endif]-->
+                </div>
+                <!--[if mso ]>
+                      </td><td>
+                <![endif]-->
+                <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">Мультиаккаунт</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td colspan="2">
+                <![endif]-->
+                <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">Соберите все почтовые ящики в этом приложении. Пользуйтесь ими одновременно, переключаясь в один клик.</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                  </table>
+                <![endif]-->
+              </div>
+              <!--[if mso ]>
+                    </td>
+                  </tr>
+                </table>
+              <![endif]-->
+            </div>
+            <div class="two-column" style="margin-bottom: 60px;">
+              <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                  <tr>
+                    <td width="50%">
+              <![endif]-->
+              <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">
+                <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="90%">
+                    <tr>
+                      <td>
+                <![endif]-->
+                <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">
+                  <!--[if !mso]><!-- -->
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/003.png" width="100%" alt="">
+                  <!--<![endif]-->
+                  <!--[if mso]>
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/003.png" width="48"  alt="">
+                  <!--<![endif]-->
+                </div>
+                <!--[if mso ]>
+                      </td><td>
+                <![endif]-->
+                <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">Настройки уведомлений о письмах</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td colspan="2">
+                <![endif]-->
+                <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">Настройте уведомления о новых письмах. Благодаря гибкой системе настроек можно получать уведомления о письмах из определенной папки или в определенное время.</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                  </table>
+                <![endif]-->
+              </div>
+              <!--[if mso ]>
+                  </td><td width="50%">
+              <![endif]-->
+              <div class="feature" style="width: 50%;margin: 30px;display: table-cell;">
+                <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="90%">
+                    <tr>
+                      <td>
+                <![endif]-->
+                <div class="icon" style="display: table-cell;vertical-align: middle;text-align: left;width: 48px;padding-right: 20px;padding-left: 20px;">
+                  <!--[if !mso]><!-- -->
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/001.png" width="100%" alt="">
+                  <!--<![endif]-->
+                  <!--[if mso]>
+                    <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/001.png" width="48"  alt="">
+                  <!--<![endif]-->
+                </div>
+                <!--[if mso ]>
+                      </td><td>
+                <![endif]-->
+                <div class="title" style="font-family: arial, sans-serif;display: table-cell;vertical-align: middle;text-align: left;padding-right: 20px;font-size: 20px;font-weight: bold;line-height: 28px;">Чтение писем без подключения к интернету</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td colspan="2">
+                <![endif]-->
+                <div class="description" style="font-family: arial, sans-serif;margin-top: 18px;padding-left: 20px;padding-right: 20px;text-align: left;font-size: 17px;line-height: 24px;">Просматривайте письма без подключения к интернету, например, находясь на борту самолёта или там, где плохо работает сотовая связь.</div>
+                <!--[if mso ]>
+                      </td>
+                    </tr>
+                  </table>
+                <![endif]-->
+              </div>
+              <!--[if mso ]>
+                    </td>
+                  </tr>
+                </table>
+              <![endif]-->
+            </div>
+          </div>
+
+          <div class="main-feature" style="padding: 48px 19px 60px;background: #f0f0f0;text-align: center;background-image: url(https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/pattern.png);background-position: 50% 50%;background-size: contain;background-repeat: no-repeat;">
+            <div class="title" style="font-family: arial, sans-serif;padding: 0 0 28px;font-size: 28px;color: #000000;text-align: center;line-height: 36px;">Синхронизация почты на всех устройствах</div>
+            <div class="image" style="padding: 0 20px;">
+              <!--[if !mso]><!-- -->
+                <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/bitmap.png" width="100%" height="100%" alt=""></div>
+              <!--<![endif]-->
+              <!--[if mso]>
+                <img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/bitmap.png" width="680" height="100%" alt=""></div>
+              <!--<![endif]-->
+
+            <div class="description" style="font-family: arial, sans-serif;padding: 44px 0 0;font-size: 20px;color: #000000;text-align: center;line-height: 28px;">В приложении есть всё необходимое для работы с почтой: список писем с аватарками, возможность отправлять и получать вложения, персональный спам-фильтр, цепочки писем и многое другое.</div>
+          </div>
+
+          <div class="footer" style="margin: 48px 19px 60px;text-align: center;">
+            <div class="title" style="font-family: arial, sans-serif;margin-bottom: 24px;font-size: 20px;color: #323232;line-height: 23px;">
+              Следите за нашими новостями
+              <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTcxLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTUzIn0.vHYFhCdC6FMc4m188LIB7ogyQjHF-e11ShV6WvfQSgk" class="link" style="color: #005bd1;text-decoration: none;" data-url-index="43571">в блоге</a>
+              Почты и социальных сетях:
+            </div>
+            <div class="social-links" style="margin-bottom: 34px;">
+              <!--[if mso ]>
+                <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                  <tr>
+                    <td>
+              <![endif]-->
+              <div class="social-link social-link_vk" style="display: inline;margin: 10px;"><a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTcyLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTE5In0.NyXnXmPqvfYt6dwlaTG83kM5aNywpttkSHMe0iXYcdA" data-url-index="43572"><img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_vk.png" width="64" height="64"></a></div>
+              <!--[if mso ]>
+                    </td><td>
+              <![endif]-->
+              <div class="social-link social-link_vk" style="display: inline;margin: 10px;"><a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTczLCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTExIn0.1Cp_IPfvy9wmwoLjHm1PyL-skQ95WPThiugjmlVHZv8" data-url-index="43573"><img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_ok.png" width="64" height="64"></a></div>
+              <!--[if mso ]>
+                    </td><td>
+              <![endif]-->
+              <div class="social-link social-link_vk" style="display: inline;margin: 10px;"><a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc0LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyNzY0In0.EZ-vMKQ7imp6cro3s0xRrHIG1MCB8nfH47mPgVrAX4w" data-url-index="43574"><img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_facebook.png" width="64" height="64"></a></div>
+              <!--[if mso ]>
+                    </td><td>
+              <![endif]-->
+              <div class="social-link social-link_vk" style="display: inline;margin: 10px;"><a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc1LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTU1In0.iDoqOSwgNKgJP7bWXJ52ogG33trO48EJ_NhSSywrYDQ" data-url-index="43575"><img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_twitter.png" width="64" height="64"></a></div>
+              <!--[if mso ]>
+                    </td><td>
+              <![endif]-->
+              <div class="social-link social-link_vk" style="display: inline;margin: 10px;"><a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc2LCJ1cmwiOiJodHRwczovL3IubWFpbC5ydS9uMjI1MzYyOTQ4In0.Bt67abHLZp_rhmUGETKt-GPxu419RBvR4sflHDT0rCY" data-url-index="43576"><img src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/social_moymir.png" width="64" height="64"></a></div>
+              <!--[if mso ]>
+                    </td>
+                  </tr>
+                </table>
+              <![endif]-->
+            </div>
+            <div class="separator" style="margin: 0 74px;line-height: 1px;border-bottom: 1px solid #999;"></div>
+            <div class="description" style="font-family: arial, sans-serif;font-size: 20px;color: #999999;line-height: 28px;">
+              <p>
+                Если у вас возникнут
+                какие-нибудь проблемы
+                с настройкой почты, вы
+                может воспользоваться
+                нашей онлайн <a href="https://mailer.mail.ru/pub/mailer/click/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUiLCJ1cmxfaWQiOjQzNTc3LCJ1cmwiOiJodHRwczovL2hlbHAubWFpbC5ydS9tYWlsLWhlbHAvIn0.AdeI6Dt9VTNgoxm_kJwHaognuYnOi-yZPHAaZtzbOE4" class="link" style="color: #005bd1;text-decoration: none;" data-url-index="43577">помощью</a>
+              </p>
+              <p>
+                С наилучшими пожеланиями, команда Почты Mail.ru
+              </p>
+            </div>
+            <div class="copy" style="font-size: 13px;color: #999999;line-height: 24px;">
+              Mail.ru Group, Москва -
+              Все&nbsp;права защищены.
+            </div>
+            <div class="logo" style="margin: 24px 0;">
+              <img
+                src="https://mailer.mail.ru/media/letter/static/2019/4/12/FMOsCMR4gfUXmge/img/32_-mail_g.png"
+                style="width:95px;height:32px;" alt="@Mail.ru"
+                height="32" width="95">
+            </div>
+          </div>
+        </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+<div style="background-color: #fff"><img src="https://mailer.mail.ru/pub/mailer/pixel/3001/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsZXR0ZXJfaWQiOjMwMDEsImVtYWlsIjoiYmF0bWFuMTExNTU1QG1haWwucnUiLCJ0ZXN0aW5nIjowLCJwb3N0X3R5cGUiOiJDIiwicG9zdF9pZCI6NDIsInNlbmRfdXVpZCI6ImVhNzMzNzU0LTM0MWQtNGQ0Yi04ZDJjLTcwYWMwYzBiOWJmNCIsImxhbmd1YWdlIjoicnUifQ.kBxrr6UFII4HGPuEInkOKX_MpZKSCLhZk6lGnVCJyC8" width="0" height="0" alt="."/></div></body>
+</html>


### PR DESCRIPTION
As discsussed in #9 , current implementation still wasn't perfect, so I reimplemented RTF to HTML converter to parse RTF according to RTF spec.

Had to change test data of two existing tests: 
1. Chinise email input html - it was broken, having extra line-breaks where not needed. I checked carefully all differences: current result seems to be correct one. All Chinise characters match exactly.
2. Removed logic of wrapping with <html><body> tags - not quite understand the meaning of that - if rtf doesn't print <html> tags - then they shouldn't be in the output.

Tested this implementation on multiple very complex emails - all emails exactly match HTML source from Outlook (extracted by clicking View Source on an email)
