### PR TITLE
Use real Outlook ContentId Attribute to resolve CID Attachments

### DIFF
--- a/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookFileAttachment.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookFileAttachment.java
@@ -21,6 +21,10 @@ public class OutlookFileAttachment implements OutlookAttachment {
 	 */
 	private String mimeTag;
 	/**
+	 * CID of the attachment
+	 */
+	private String contentId;
+	/**
 	 * The extension of the attachment (may not be set).
 	 */
 	private String extension;
@@ -58,6 +62,9 @@ public class OutlookFileAttachment implements OutlookAttachment {
 				case "3703":
 					setExtension((String) value);
 					break;
+				case "3712":
+					setContentId((String) value);
+					break;
 				default:
 					// property to ignore, for full list see properties-list.txt
 			}
@@ -87,6 +94,21 @@ public class OutlookFileAttachment implements OutlookAttachment {
 	@Override
 	public String toString() {
 		return (longFilename != null) ? longFilename : filename;
+	}
+
+	/**
+	 * Bean getter for {@link #contentId}.
+	 */
+	@SuppressWarnings("ElementOnlyUsedFromTestCode")
+	public String getContentId() {
+		return contentId;
+	}
+
+	/**
+	 * Bean setter for {@link #contentId}.
+	 */
+	void setContentId(final String contentId) {
+		this.contentId = contentId;
 	}
 
 	/**

--- a/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookMessage.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookMessage.java
@@ -313,9 +313,7 @@ public class OutlookMessage {
 			for (final OutlookAttachment attachment : getOutlookAttachments()) {
 				if (attachment instanceof OutlookFileAttachment) {
 					final OutlookFileAttachment fileAttachment = (OutlookFileAttachment) attachment;
-					if (!tryAddCid(cidMap, html, fileAttachment, fileAttachment.getFilename())) {
-						tryAddCid(cidMap, html, fileAttachment, fileAttachment.getLongFilename());
-					}
+					tryAddCid(cidMap, html, fileAttachment, fileAttachment.getContentId());
 				}
 			}
 		}

--- a/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookMessage.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookMessage.java
@@ -313,7 +313,11 @@ public class OutlookMessage {
 			for (final OutlookAttachment attachment : getOutlookAttachments()) {
 				if (attachment instanceof OutlookFileAttachment) {
 					final OutlookFileAttachment fileAttachment = (OutlookFileAttachment) attachment;
-					tryAddCid(cidMap, html, fileAttachment, fileAttachment.getContentId());
+					if (!tryAddCid(cidMap, html, fileAttachment, fileAttachment.getContentId())) {
+						if (!tryAddCid(cidMap, html, fileAttachment, fileAttachment.getFilename())) {
+							tryAddCid(cidMap, html, fileAttachment, fileAttachment.getLongFilename());
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Outlook saves the CID in MSG Files using Attribute 3712. This merge request allows the usage of this attribute for the ContentId