### PR TITLE
Bugfix: __nameid_ directory should not be parsed

### DIFF
--- a/src/main/java/org/simplejavamail/outlookmessageparser/OutlookMessageParser.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/OutlookMessageParser.java
@@ -176,6 +176,9 @@ public class OutlookMessageParser {
 				} else if (de.getName().startsWith("__recip_version1.0")) {
 					// a recipient entry has been found (which is also a directory entry itself)
 					checkRecipientDirectoryEntry(de, msg);
+				} else if (de.getName().startsWith("__nameid_version1.0")) {
+					// a named property mapping directory has been found. We have to ignore it because 
+					// we can not parse it yet and it creates conflicts with normal parsing see also [MS-OXMSG]
 				} else {
 					// a directory entry has been found. this node will be recursively checked
 					checkDirectoryEntry(de, msg);


### PR DESCRIPTION
In a MSG file the __nameid_... directory represents named properties, which are as of right now not supported by this library. It tries to parse the entries in this directory using the normal property parser though, which creates conflicts and is wrong. You can also refer to the Microsoft documentation for this: [MS-OXMSG].

I had several emails where an id in this directory collided with the property id for HTML-Content (10130102), which caused RTF-Emails to incorrctly report this invalid content as the HTML body, which prevented the RTF Conversion from being read.

![grafik](https://user-images.githubusercontent.com/13820214/72885510-5dbe3280-3d08-11ea-8d14-78b4f0eb9418.png)
