### PR TITLE
Adjust dependencies and make Java 9+ friendly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
 			<artifactId>rtf-to-html</artifactId>
 			<version>1.0.1</version>
 		</dependency>
+		<dependency>
+			<groupId>com.sun.activation</groupId>
+			<artifactId>jakarta.activation</artifactId>
+			<version>2.0.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,14 @@
 			<artifactId>jakarta.activation</artifactId>
 			<version>2.0.1</version>
 		</dependency>
+		<!-- required for java 9+ compatibility with assertj-assertions-generator-maven-plugin, which uses javax.annotation.Generated -->
+		<!-- see https://github.com/assertj/assertj-assertions-generator-maven-plugin/issues/93 -->
+		<dependency>
+			<groupId>jakarta.annotation</groupId>
+			<artifactId>jakarta.annotation-api</artifactId>
+			<version>1.3.5</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/simplejavamail/outlookmessageparser/model/MimeType.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/model/MimeType.java
@@ -1,6 +1,6 @@
 package org.simplejavamail.outlookmessageparser.model;
 
-import javax.activation.MimetypesFileTypeMap;
+import jakarta.activation.MimetypesFileTypeMap;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookFileAttachment.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookFileAttachment.java
@@ -1,7 +1,5 @@
 package org.simplejavamail.outlookmessageparser.model;
 
-import javax.activation.MimetypesFileTypeMap;
-
 /**
  * Implementation of the {@link OutlookAttachment} interface that represents a file attachment. It contains some useful information (as long as it is available
  * in the .msg file) like the attachment name, its size, etc.


### PR DESCRIPTION
- Remove unnecessary import of javax.activation.MimetypesFileTypeMap.
- Add jakarta.activation as dependency and switch to newer version in jakarta namespace.
- Add jakarta.annotation-api as a test dependency since it is required for assertj-assertions-generator-maven-plugin.