### PR TITLE
Fix #62: MimeType NoClassDefFoundError

### DIFF
--- a/src/main/java/org/simplejavamail/outlookmessageparser/model/MimeType.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/model/MimeType.java
@@ -12,7 +12,7 @@ class MimeType {
      * @return a vastly improved mimetype map
      */
     private static MimetypesFileTypeMap createMap() {
-        try (InputStream is = MimeType.class.getClassLoader().getResourceAsStream("mimetypes.txt")) {
+        try (InputStream is = MimeType.class.getResourceAsStream("/mimetypes.txt")) {
             return new MimetypesFileTypeMap(is);
         } catch (IOException ex) {
             throw new RuntimeException(ex);


### PR DESCRIPTION
See
https://stackoverflow.com/questions/16570523/getresourceasstream-returns-null; the two fixes are

  - call the class' `getResourceAsStream()` instead of the ClassLoader's
  - use an absolute path to get the resource.

Passes `mvn test` here.