### PR TITLE
Adding possibility to parse X500 Names

### DIFF
--- a/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookRecipient.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookRecipient.java
@@ -72,6 +72,9 @@ public class OutlookRecipient {
 			if (this.address == null && probablyNamePossiblyAddress.contains("@")) {
 				setAddress(probablyNamePossiblyAddress);
 				nameWasUsedAsAddress = true;
+			} else if (this.address == null && probablyNamePossiblyAddress.startsWith("/o=ExchangeLabs/ou=Exchange Administrative Group")) {
+				setAddress(probablyNamePossiblyAddress);
+				nameWasUsedAsAddress = false;
 			}
 		}
 	}


### PR DESCRIPTION
this is a possible fix for the Issue from "Recipient as Exchange Member will throw Exception emailAddressList is required #477" in the Java Simple Mail Repo.