### PR TITLE
#77 exclude creator/modifier from setFromEmail

### DIFF
--- a/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookMessage.java
+++ b/src/main/java/org/simplejavamail/outlookmessageparser/model/OutlookMessage.java
@@ -201,8 +201,9 @@ public class OutlookMessage {
 				break;
 			case 0xc1f: //SENDER EMAIL ADDRESS
 			case 0x65: //SENT REPRESENTING EMAIL ADDRESS
-			case 0x3ffa: //LAST MODIFIER NAME
 				setFromEmail(stringValue);
+				break;
+			case 0x3ffa: //LAST MODIFIER NAME
 				break;
 			case 0x42: //SENT REPRESENTING NAME
 				setFromName(stringValue);
@@ -527,7 +528,7 @@ public class OutlookMessage {
 	 * @param force     forces overwriting of the field if already set
 	 */
 	private void setFromEmail(final String fromEmail, final boolean force) {
-		if ((force || this.fromEmail == null) && fromEmail != null && fromEmail.contains("@")) {
+		if (force || this.fromEmail == null) {
 			this.fromEmail = fromEmail;
 		}
 	}


### PR DESCRIPTION
1. the property 0x3ffa refers to the creator/last modifier of the message object and it may be unrelated to the sender of the message.
2. the setFromEmail must allow X500 data if the variable is null (and removed unnecessary/duplicated check for "@")