### PR TITLE
Upgrade POI to 5.4.1 for CVE-2025-31672

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.2.5</version>
+			<version>5.4.1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Apache POI has a vulnerability : https://nvd.nist.gov/vuln/detail/CVE-2025-31672
Upgrading to latest.